### PR TITLE
solr: fix accidental removal of persistence volume mount when backport from previous PAVICS repo

### DIFF
--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -205,6 +205,8 @@ services:
     ports:
       - "8983:8983"
       - "48983:9001"
+    volumes:
+      - /data/solr:/data
     volumes_from:
       - mongodb
     restart: always


### PR DESCRIPTION
Bad backport f8391a2cc4b2ffc3ef57c11add6b0b38643572ba removed the
persistence volume mount.