### PR TITLE
backup solr: should save all of /data/solr, not just the index

### DIFF
--- a/birdhouse/scripts/backup-restore-solr-index
+++ b/birdhouse/scripts/backup-restore-solr-index
@@ -37,7 +37,7 @@ if [ x"$MODE" = xbackup ]; then
     docker run --rm --name $BACKUP_CONTAINER_NAME \
         --volumes-from $SOLR_CONTAINER_NAME \
         -v $BACKUP_BASEDIR:/backup -w / bash \
-        tar czf "/backup/$BACKUP_FILENAME" data/solr/birdhouse/data/index/
+        tar czf "/backup/$BACKUP_FILENAME" data/solr/
 elif [ x"$MODE" = xrestore ]; then
     docker run --rm --name $BACKUP_CONTAINER_NAME \
         --volumes-from $SOLR_CONTAINER_NAME \


### PR DESCRIPTION
The `catalog_search.ipynb`
(https://pavics.ouranos.ca/jupyter/user/public/lab/tree/tutorial-notebooks/catalog_search.ipynb)
notebook was failing with this error:

owslib.wps.WPSException : {'code': 'NoApplicableCode', 'locator': 'None', 'text': 'Process error: method=wps_pavicsearch.py._handler, line=254, msg=Traceback (most recent call last):\n  File "/usr/local/lib/python2.7/dist-packages/pavics_datacatalog-0.6.11-py2.7.egg/pavics_datacatalog/wps_processes/wps_pavicsearch.py", line 251, in _handler\n    output_format=output_format)\n  File "/usr/local/lib/python2.7/dist-packages/pavics/catalog.py", line 973, in pavicsearch\n    r.raise_for_status()\n  File "/usr/lib/python2.7/dist-packages/requests/models.py", line 840, in raise_for_status\n    raise HTTPError(http_error_msg, response=self)\nHTTPError: 400 Client Error: Bad Request for url: http://pavics.ouranos.ca:8983/solr/birdhouse/select?start=0&rows=10&q=*&fq=variable:%22tasmin%22&fq=project:%22CMIP5%22&fq=experiment:%22rcp85%22&fq=frequency:%22day%22&fl=*,score&fq=type:File&sort=id+asc&wt=json&indent=true\n'}

Interestingly the canarie monitoring of the Catalog service was working fine.

It turns out the file `/data/solr/birdhouse/conf/managed-schema` was important.

Diff of that `managed-schema` file against a working one from CRIM:

```diff
$ diff /data/solr/solr/birdhouse/conf/managed-schema /tmp/good-file
1c1
< <?xml version="1.0" encoding="UTF-8"?>
---
> <?xml version="1.0" encoding="UTF-8"?>
48a49,51
>   <field name="dataset_id" type="string" stored="true"/>
>   <field name="datetime_max" type="date" stored="true"/>
>   <field name="datetime_min" type="date" stored="true"/>
50a54
>   <field name="fileserver_url" type="string" stored="true"/>
55a60
>   <field name="latest" type="boolean" stored="true"/>
58a64
>   <field name="replica" type="boolean" stored="true"/>
63a70
>   <field name="type" type="string" stored="true"/>
```

The good file has a few more fields !

Replaced the bad file with the good file and the `catalog_search.ipynb`
works again.

Will launch the crawler again to really refresh the data but at least now the
Catalog service is working.