### PR TITLE
catalog: use public hostname in config when using self-signed SSL behind real SSL from pagekite

### DIFF
--- a/birdhouse/config/catalog/catalog.cfg.template
+++ b/birdhouse/config/catalog/catalog.cfg.template
@@ -3,7 +3,7 @@ solr_host=http://${PAVICS_FQDN}:8983/solr/birdhouse/
 
 # Multiple thredds hosts can be given, comma separated
 # note: this URL is also used as prefix when comparing authorizations from magpie
-thredds_host=https://${PAVICS_FQDN}${TWITCHER_PROTECTED_PATH}/thredds
+thredds_host=https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/thredds
 
 # Multiple esgf nodes can be given, comma separated
 esgf_nodes=https://esgf-node.llnl.gov/esg-search
@@ -11,7 +11,7 @@ esgf_nodes=https://esgf-node.llnl.gov/esg-search
 # Provide a magpie host to filter results based on access permissions.
 # Must also provide credentials with read access so that the crawler can parse the thredds host(s)
 # Leave as a comment for a public catalog.
-magpie_host=https://${PAVICS_FQDN}/magpie
+magpie_host=https://${PAVICS_FQDN_PUBLIC}/magpie
 magpie_user=${CATALOG_USERNAME}
 magpie_pw=${CATALOG_PASSWORD}
 # SSL verification (true or false)
@@ -22,11 +22,13 @@ thredds_host_magpie_svc_name=${CATALOG_THREDDS_SERVICE}
 # WMS service url with <HOST> replaced by each instance of the thredds_host,
 # without the port number and <DATASET> replaced by the base url in thredds.
 # Leave as comment to use the default WMS service
-wms_alternate_server=https://${PAVICS_FQDN}${TWITCHER_PROTECTED_PATH}/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0&DATASET=outputs/<DATASET>
+wms_alternate_server=https://${PAVICS_FQDN_PUBLIC}${TWITCHER_PROTECTED_PATH}/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0&DATASET=outputs/<DATASET>
 
 [pywps]
 outputurl=https://${PAVICS_FQDN_PUBLIC}/wpsoutputs/catalog
 parallelprocesses=30
 
 [logging]
+#level=DEBUG
+#file=/tmp/wps.log
 database=postgresql://${POSTGRES_PAVICS_USERNAME}:${POSTGRES_PAVICS_PASSWORD}@postgres/catalog


### PR DESCRIPTION
Fix magpie connection error like:

```
<ows:ExceptionText>Process error: method=wps_pavicrawler.py._handler, line=146, msg=Traceback (most recent call last):
  File &#34;/usr/local/lib/python2.7/dist-packages/pavics_datacatalog-0.6.11-py2.7.egg/pavics_datacatalog/wps_processes/wps_pavicrawler.py&#34;, line 125, in _handler
    verify=self.verify)
  File &#34;/usr/lib/python2.7/dist-packages/requests/sessions.py&#34;, line 523, in post
    return self.request(&#39;POST&#39;, url, data=data, json=json, **kwargs)
  File &#34;/usr/lib/python2.7/dist-packages/requests/sessions.py&#34;, line 480, in request
    resp = self.send(prep, **send_kwargs)
  File &#34;/usr/lib/python2.7/dist-packages/requests/sessions.py&#34;, line 588, in send
    r = adapter.send(request, **kwargs)
  File &#34;/usr/lib/python2.7/dist-packages/requests/adapters.py&#34;, line 447, in send
    raise SSLError(e, request=request)
SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
</ows:ExceptionText>
```

Thredds url need to use the public hostname too so the path recorded in Solr is
the good public one.

The wms_alternate_server, not sure what it impact but looks like it might be
useful so change it too.

Fixed needed to investigate the crawling problem in https://github.com/bird-house/birdhouse-deploy/pull/4#issuecomment-577477936