### PR TITLE
jupyter data migration: touch new location else jupyterhub won't bind mount them

### DIFF
--- a/birdhouse/scripts/migrate-jupyterhub-user-persistence
+++ b/birdhouse/scripts/migrate-jupyterhub-user-persistence
@@ -15,5 +15,7 @@ set -x
 $BASE_CMD bash -c "mkdir -p /data/jupyterhub_user_data/public \
     && cp -r /jpuser/* /data/jupyterhub_user_data/public/ \
     && rm -rf /data/jupyterhub_user_data/public/tutorial-notebooks \
+    && touch /data/jupyterhub_user_data/tutorial-notebooks \
     && rm /data/jupyterhub_user_data/public/README.ipynb \
+    && touch /data/jupyterhub_user_data/README.ipynb \
     && chown -R 1000:1000 /data/jupyterhub_user_data/public"


### PR DESCRIPTION
See PR https://github.com/bird-house/birdhouse-deploy/pull/16
or commit
https://github.com/bird-house/birdhouse-deploy/commit/53576cc9d36642c50e4a649ca58fc8339559fd4a

See the `if os.path.exists` in the `jupyterhub_config.py`:
https://github.com/bird-house/birdhouse-deploy/blob/53576cc9d36642c50e4a649ca58fc8339559fd4a/birdhouse/config/jupyterhub/jupyterhub_config.py.template#L36-L48