### PR TITLE
Optionally monitor all components behind Twitcher using canarie api

### DIFF
--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -1,4 +1,10 @@
 # All env this common.env can be overridden by env.local.
 
+# Jupyter single-user server image
 export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200120"
+
+# Folder on the host to persist Jupyter user data (noteboooks, HOME settings)
 export JUPYTERHUB_USER_DATA_DIR="/data/jupyterhub_user_data"
+
+# Folder inside "proxy" container to drop extra monitoring config
+export CANARIE_MONITORING_EXTRA_CONF_DIR="/conf.d"

--- a/birdhouse/config/canarie-api/docker_configuration.py.template
+++ b/birdhouse/config/canarie-api/docker_configuration.py.template
@@ -1,4 +1,8 @@
 # coding: utf-8
+import os
+import logging
+
+logger = logging.getLogger("canarie-api-config")
 
 MY_SERVER_NAME = 'https://${PAVICS_FQDN_PUBLIC}/canarie'
 
@@ -273,3 +277,17 @@ PLATFORMS = {
         }
     }
 }
+
+CANARIE_MONITORING_EXTRA_CONF_DIR = os.environ.get(
+    'CANARIE_MONITORING_EXTRA_CONF_DIR', '/bogus-notexist')
+
+if os.path.exists(CANARIE_MONITORING_EXTRA_CONF_DIR):
+    # alphabetically sorted for reproducible override precedence
+    for extra_conf in sorted(os.listdir(CANARIE_MONITORING_EXTRA_CONF_DIR)):
+        extra_conf_full_path = "{CANARIE_MONITORING_EXTRA_CONF_DIR}/{extra_conf}".format(**locals())
+        # only handle files ending with .py
+        if os.path.isfile(extra_conf_full_path) and extra_conf_full_path.endswith(".py"):
+            logger.info("canarie-api: loading extra config '{extra_conf_full_path}'".format(**locals()))
+            execfile(extra_conf_full_path)
+        else:
+            logger.info("canarie-api: ignoring extra config '{extra_conf_full_path}'".format(**locals()))

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ./config/canarie-api/entrypoint:/entrypoint:ro
     environment:
       CANARIE_API_CONFIG_FN: /config/docker_configuration.py
+      CANARIE_MONITORING_EXTRA_CONF_DIR: ${CANARIE_MONITORING_EXTRA_CONF_DIR}
     links:
       - thredds
     entrypoint: /entrypoint

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -55,8 +55,7 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # Format: space separated list of dirs
 #
 #export EXTRA_CONF_DIRS="/path/to/dir1 ./path/to/dir2 dir3 dir4"
-#export EXTRA_CONF_DIRS="./private-config ./optional-components/emu"
-#export EXTRA_CONF_DIRS="./private-config"
+#export EXTRA_CONF_DIRS="./optional-components/emu /path/to/private-config-repo"
 
 # Extra repos, than the current repo, the autodeploy should keep up-to-date.
 # Any changes to these extra repos will also trigger autodeploy.

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -55,7 +55,8 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # Format: space separated list of dirs
 #
 #export EXTRA_CONF_DIRS="/path/to/dir1 ./path/to/dir2 dir3 dir4"
-#export EXTRA_CONF_DIRS="./optional-components/emu /path/to/private-config-repo"
+#export EXTRA_CONF_DIRS="./optional-components/canarie-api-full-monitoring
+#    ./optional-components/emu /path/to/private-config-repo"
 
 # Extra repos, than the current repo, the autodeploy should keep up-to-date.
 # Any changes to these extra repos will also trigger autodeploy.

--- a/birdhouse/optional-components/README.md
+++ b/birdhouse/optional-components/README.md
@@ -1,5 +1,20 @@
 # Optional components
 
+## Monitor all components in Canarie node, both public and internal url
+
+So that the url https://<PAVICS_FQDN>/canarie/node/service/stats also return
+what the end user really see (a component might work but is not accessible to
+the end user).
+
+This assume all the WPS services are public.  If not the case, make a copy of
+this config and adjust accordingly.
+
+How to enable this config in `env.local` (a copy from
+[`env.local.example`](../env.local.example)):
+
+* Add `./optional-components/canarie-api-full-monitoring` to `EXTRA_CONF_DIRS`.
+
+
 ## Emu WPS service for testing
 
 How to enable Emu in `env.local` (a copy from

--- a/birdhouse/optional-components/canarie-api-full-monitoring/.gitignore
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/.gitignore
@@ -1,0 +1,1 @@
+canarie_api_full_monitoring.py

--- a/birdhouse/optional-components/canarie-api-full-monitoring/a_demo_override_precedence.py
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/a_demo_override_precedence.py
@@ -1,0 +1,10 @@
+# This file will be overridden by canarie_api_full_monitoring.py.template
+# because they are loaded in alphabetical sorted order and the last one have
+# highest override precedence.
+SERVICES['node']['monitoring'].update({
+    'Thredds-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/toto',
+        },
+    },
+})

--- a/birdhouse/optional-components/canarie-api-full-monitoring/canarie_api_full_monitoring.py.template
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/canarie_api_full_monitoring.py.template
@@ -1,0 +1,7 @@
+SERVICES['node']['monitoring'].update({
+    'Thredds-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/thredds/catalog.html',
+        },
+    },
+})

--- a/birdhouse/optional-components/canarie-api-full-monitoring/canarie_api_full_monitoring.py.template
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/canarie_api_full_monitoring.py.template
@@ -4,4 +4,37 @@ SERVICES['node']['monitoring'].update({
             'url': 'https://${PAVICS_FQDN_PUBLIC}/thredds/catalog.html',
         },
     },
+    # Flyingpigeon is used for Twitcher monitoring already
+    'Catalog-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/catalog?service=WPS&version=1.0.0&request=GetCapabilities'
+        },
+    },
+    'Malleefowl-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/malleefowl?service=WPS&version=1.0.0&request=GetCapabilities'
+        }
+    },
+    'Finch-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/finch?service=WPS&version=1.0.0&request=GetCapabilities'
+        }
+    },
+    'Raven-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/raven?service=WPS&version=1.0.0&request=GetCapabilities'
+        }
+    },
+    'Hummingbird-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/hummingbird?service=WPS&version=1.0.0&request=GetCapabilities'
+        }
+    },
+    'ncWMS2-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0'
+        }
+    },
 })
+
+# vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4 syntax=python

--- a/birdhouse/optional-components/canarie-api-full-monitoring/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/docker-compose-extra.yml
@@ -1,0 +1,7 @@
+version: '2.1'
+services:
+  proxy:
+    volumes:
+      - ./optional-components/canarie-api-full-monitoring/canarie_api_full_monitoring.py:${CANARIE_MONITORING_EXTRA_CONF_DIR}/canarie_api_full_monitoring.py:ro
+
+# vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/optional-components/canarie-api-full-monitoring/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/docker-compose-extra.yml
@@ -3,5 +3,7 @@ services:
   proxy:
     volumes:
       - ./optional-components/canarie-api-full-monitoring/canarie_api_full_monitoring.py:${CANARIE_MONITORING_EXTRA_CONF_DIR}/canarie_api_full_monitoring.py:ro
+      - ./optional-components/canarie-api-full-monitoring/a_demo_override_precedence.py:${CANARIE_MONITORING_EXTRA_CONF_DIR}/a_demo_override_precedence.py:ro
+      - ./optional-components/canarie-api-full-monitoring/z_demo_only_py_file_are_loaded.wrongsuffix:${CANARIE_MONITORING_EXTRA_CONF_DIR}/z_demo_only_py_file_are_loaded.wrongsuffix:ro
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/optional-components/canarie-api-full-monitoring/z_demo_only_py_file_are_loaded.wrongsuffix
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/z_demo_only_py_file_are_loaded.wrongsuffix
@@ -1,0 +1,8 @@
+# This file will not be loaded since it does not end with ".py".
+SERVICES['node']['monitoring'].update({
+    'Thredds-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/wrong-suffix',
+        },
+    },
+})

--- a/birdhouse/pavics-compose.sh
+++ b/birdhouse/pavics-compose.sh
@@ -109,8 +109,7 @@ if [ -z "$VERIFY_SSL" ]; then
 fi
 
 # we apply all the templates
-# FIXME: 'private-config' to be removed when moved to other repo
-find ./config ./private-config ./optional-components -name '*.template' -print0 |
+find ./config ./optional-components -name '*.template' -print0 |
   while IFS= read -r -d $'\0' FILE
   do
     DEST=${FILE%.template}


### PR DESCRIPTION
Fixes https://github.com/bird-house/birdhouse-deploy/issues/8

The motivation was the need for some quick dashboard for the working state of all the components, not to get more stats.

Right now we bypassing Twitcher, which is not real life, it's not what real users will experience.

This is ultra cheap to add and provide very fast and up-to-date (every minute) result. It's like an always on sanity check that can quickly help debugging any connectivity issues between the components.

It is optional because it assumes all components are publicly accessible.  Might not be the case for everyone.  We can also override the override :D

All components in config/canarie-api/docker_configuration.py.template that do not have public (behind Twitcher) monitoring are added.

Also added Hummingbird and ncWMS2 public monitoring.

@tlogan2000 This will catch accidental Thredds public url breakage like last time and will leverage the existing monitoring on https://pavics.ouranos.ca/canarie/node/service/stats by @moulab88.

@davidcaron @dbyrns This is optional so if the CRIM do not want to enable it, it's fine.

New node monitoring page:

![Screenshot_2020-02-07 Ouranos - Node Service](https://user-images.githubusercontent.com/11966697/74055606-4a6cc180-49ae-11ea-9cba-887118dbaae6.png)
