### PR TITLE
catalog: fix pavicsearch broken due to typo in config

### DIFF
--- a/birdhouse/config/catalog/catalog.cfg.template
+++ b/birdhouse/config/catalog/catalog.cfg.template
@@ -3,7 +3,7 @@ solr_host=http://${PAVICS_FQDN}:8983/solr/birdhouse/
 
 # Multiple thredds hosts can be given, comma separated
 # note: this URL is also used as prefix when comparing authorizations from magpie
-thredds_host=https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/thredds
+thredds_host=https://${PAVICS_FQDN_PUBLIC}${TWITCHER_PROTECTED_PATH}/thredds
 
 # Multiple esgf nodes can be given, comma separated
 esgf_nodes=https://esgf-node.llnl.gov/esg-search


### PR DESCRIPTION
The `thredds_host` should be the exact prefix of each document url found
in Solr, otherwise it is removed from the search result.

This explains why pavicsearch was returning nothing.

This will fix the `catalog_search.ipynb` notebook that keeps failing on Jenkins.

The typo was introduced in PR
https://github.com/bird-house/birdhouse-deploy/pull/5, commit
https://github.com/bird-house/birdhouse-deploy/commit/83c839178fff170dbcb4c4e0586e67d19b9cfbc5

Edit:
* add "This will fix the `catalog_search.ipynb` notebook that keeps failing on Jenkins."