### PR TITLE
proxy: fix canarie-api solr query not precise enough breaking the monitoring

### DIFF
--- a/birdhouse/config/canarie-api/docker_configuration.py.template
+++ b/birdhouse/config/canarie-api/docker_configuration.py.template
@@ -84,7 +84,7 @@ SERVICES = {
             },
             'Solr': {
                 'request': {
-                    'url': 'http://${PAVICS_FQDN}:8983/solr/birdhouse/select?q=CMIP5&wt=json'
+                    'url': 'http://${PAVICS_FQDN}:8983/solr/birdhouse/select?q=CMIP5&fq=model=CanESM2&fq=experiment:rcp85&wt=json'
                 },
                 'response': {
                     'text': '.*catalog_url\":\".+${CMIP5_THREDDS_ROOT}/CanESM2/rcp85/.*/catalog.xml.*'


### PR DESCRIPTION
The original query returned the first 10 of a total of 45444.

```sh
$ curl --silent "http://pavics.ouranos.ca:8983/solr/birdhouse/select?q=CMIP5&wt=json" | json_pp | grep numFound
      "numFound" : 45444,
```

Since we re-crawled, we have new data and the first 10 entries do not
contain the response we look for anymore.

The new query is much more precise so should prevent this from happening
in the future.

```sh
$ curl --silent "http://pavics.ouranos.ca:8983/solr/birdhouse/select?q=CMIP5&fq=model=CanESM2&fq=experiment:rcp85&wt=json" | json_pp | grep numFound
      "numFound" : 10
```

@moulab88 I assume the re-crawl you triggered succeeded finally?