### PR TITLE
Autodeploy the autodeploy phase 1: tutorial notebooks only and not enabled by default

### DIFF
--- a/birdhouse/components/scheduler/config.json
+++ b/birdhouse/components/scheduler/config.json
@@ -10,6 +10,6 @@
     "comment":"Auto-deploy tutorial notebooks",
     "schedule":"@every 15m",
     "command":"${COMPOSE_DIR}/deployment/trigger-deploy-notebook",
-    "dockerargs":"--rm --name notebookdeploy --volume /var/run/docker.sock:/var/run/docker.sock:ro --volume /var/log/PAVICS:/var/log/PAVICS:rw --volume ${COMPOSE_DIR}:${COMPOSE_DIR}:rw --volume /data:/data:rw --env COMPOSE_DIR=${COMPOSE_DIR}",
+    "dockerargs":"--rm --name notebookdeploy --volume /var/run/docker.sock:/var/run/docker.sock:ro --volume /var/log/PAVICS:/var/log/PAVICS:rw --volume ${COMPOSE_DIR}:${COMPOSE_DIR}:ro --volume /data:/data:rw --volume /tmp/notebookdeploy:/tmp/notebookdeploy:rw --env COMPOSE_DIR=${COMPOSE_DIR} --env TMP_BASE_DIR=/tmp/notebookdeploy",
     "image":"docker:19.03.6-git"
 }]

--- a/birdhouse/components/scheduler/config.json
+++ b/birdhouse/components/scheduler/config.json
@@ -1,11 +1,4 @@
 [{
-    "schedule":"@every 5m",
-    "command":"env; echo toto",
-    "name":"test echo",
-    "comment":"comment test echo",
-    "dockerargs":"--rm --name testecho",
-    "image":"bash"
-},{
     "name":"notebookdeploy",
     "comment":"Auto-deploy tutorial notebooks",
     "schedule":"@every 15m",

--- a/birdhouse/components/scheduler/config.json
+++ b/birdhouse/components/scheduler/config.json
@@ -5,4 +5,11 @@
     "comment":"comment test echo",
     "dockerargs":"--rm --name testecho",
     "image":"bash"
+},{
+    "name":"notebookdeploy",
+    "comment":"Auto-deploy tutorial notebooks",
+    "schedule":"@every 15m",
+    "command":"${COMPOSE_DIR}/deployment/trigger-deploy-notebook",
+    "dockerargs":"--rm --name notebookdeploy --volume /var/run/docker.sock:/var/run/docker.sock:ro --volume /var/log/PAVICS:/var/log/PAVICS:rw --volume ${COMPOSE_DIR}:${COMPOSE_DIR}:rw --volume /data:/data:rw --env COMPOSE_DIR=${COMPOSE_DIR}",
+    "image":"docker:19.03.6-git"
 }]

--- a/birdhouse/components/scheduler/config.json
+++ b/birdhouse/components/scheduler/config.json
@@ -10,6 +10,6 @@
     "comment":"Auto-deploy tutorial notebooks",
     "schedule":"@every 15m",
     "command":"${COMPOSE_DIR}/deployment/trigger-deploy-notebook",
-    "dockerargs":"--rm --name notebookdeploy --volume /var/run/docker.sock:/var/run/docker.sock:ro --volume /var/log/PAVICS:/var/log/PAVICS:rw --volume ${COMPOSE_DIR}:${COMPOSE_DIR}:ro --volume /data:/data:rw --volume /tmp/notebookdeploy:/tmp/notebookdeploy:rw --env COMPOSE_DIR=${COMPOSE_DIR} --env TMP_BASE_DIR=/tmp/notebookdeploy",
+    "dockerargs":"--rm --name notebookdeploy --volume /var/run/docker.sock:/var/run/docker.sock:ro --volume /var/log/PAVICS:/var/log/PAVICS:rw --volume ${COMPOSE_DIR}:${COMPOSE_DIR}:ro --volume ${JUPYTERHUB_USER_DATA_DIR}:${JUPYTERHUB_USER_DATA_DIR}:rw --volume /tmp/notebookdeploy:/tmp/notebookdeploy:rw --env COMPOSE_DIR=${COMPOSE_DIR} --env TMP_BASE_DIR=/tmp/notebookdeploy --env JUPYTERHUB_USER_DATA_DIR=${JUPYTERHUB_USER_DATA_DIR}",
     "image":"docker:19.03.6-git"
 }]

--- a/birdhouse/components/scheduler/config.json
+++ b/birdhouse/components/scheduler/config.json
@@ -1,0 +1,8 @@
+[{
+    "schedule":"@every 5m",
+    "command":"env; echo toto",
+    "name":"test echo",
+    "comment":"comment test echo",
+    "dockerargs":"--rm --name testecho",
+    "image":"bash"
+}]

--- a/birdhouse/components/scheduler/docker-compose-extra.yml
+++ b/birdhouse/components/scheduler/docker-compose-extra.yml
@@ -7,6 +7,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./components/scheduler/config.json:/opt/crontab/config.json:ro
+    environment:
+      COMPOSE_DIR: ${PWD}
     restart: always
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/components/scheduler/docker-compose-extra.yml
+++ b/birdhouse/components/scheduler/docker-compose-extra.yml
@@ -9,6 +9,7 @@ services:
       - ./components/scheduler/config.json:/opt/crontab/config.json:ro
     environment:
       COMPOSE_DIR: ${PWD}
+      JUPYTERHUB_USER_DATA_DIR: ${JUPYTERHUB_USER_DATA_DIR}
     restart: always
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/components/scheduler/docker-compose-extra.yml
+++ b/birdhouse/components/scheduler/docker-compose-extra.yml
@@ -1,0 +1,12 @@
+version: '2.1'
+
+services:
+  scheduler:
+    image: willfarrell/crontab:0.5.0
+    container_name: scheduler
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./components/scheduler/config.json:/opt/crontab/config.json:ro
+    restart: always
+
+# vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -16,7 +16,9 @@ if [ -z "$JUPYTERHUB_USER_DATA_DIR" ]; then
   # running script manually (not with cron) source env.local file.
   COMPOSE_DIR="$(dirname -- "$(dirname -- "$(realpath -- "$0")")")"
   . "$COMPOSE_DIR/common.env"  # default JUPYTERHUB_USER_DATA_DIR
-  . "$COMPOSE_DIR/env.local"  # optional override JUPYTERHUB_USER_DATA_DIR
+  if [ -e "$COMPOSE_DIR/env.local" ]; then
+      . "$COMPOSE_DIR/env.local"  # optional override JUPYTERHUB_USER_DATA_DIR
+  fi
 fi
 
 LOG_FILE="/var/log/PAVICS/notebookdeploy.log"

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -14,7 +14,7 @@
 
 if [ -z "$JUPYTERHUB_USER_DATA_DIR" ]; then
   # running script manually (not with cron) source env.local file.
-  COMPOSE_DIR="$(dirname -- "$(dirname -- "$(realpath -- "$0")")")"
+  COMPOSE_DIR="$(dirname -- "$(dirname -- "$(realpath "$0")")")"
   . "$COMPOSE_DIR/common.env"  # default JUPYTERHUB_USER_DATA_DIR
   if [ -e "$COMPOSE_DIR/env.local" ]; then
       . "$COMPOSE_DIR/env.local"  # optional override JUPYTERHUB_USER_DATA_DIR

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -40,13 +40,17 @@ if [ -z "$WORKFLOW_TESTS_BRANCH" ]; then
     WORKFLOW_TESTS_BRANCH="master"
 fi
 
+if [ -z "$TMP_BASE_DIR" ]; then
+    TMP_BASE_DIR="/tmp"
+fi
+
 START_TIME="`date -Isecond`"
 echo "==========
 notebookdeploy START_TIME=$START_TIME"
 
 set -x
 
-TMPDIR="`mktemp -d -t notebookdeploy.XXXXXXXXXXXX`"
+TMPDIR="`mktemp -d -t notebookdeploy.XXXXXXXXXXXX -p $TMP_BASE_DIR`"
 
 cd $TMPDIR
 mkdir $TUTORIAL_NOTEBOOKS_DIR


### PR DESCRIPTION
We do not need to manually deploy the autodeploy mechanism (manually run all the `install-*` stcripts under https://github.com/bird-house/birdhouse-deploy/tree/master/birdhouse/deployment) because the cronjob is also a container so all scripts are always up-to-date.

This is part 1, only the tutorial notebooks auto deployment is migrated, serving as proof-of-concept.  The install script is still left behind.  Will remove all install scripts and add full documentation once all autodeployment are migrated in another PR.

Part of issue https://github.com/bird-house/birdhouse-deploy/issues/27.

It's not immediately obvious but 3 separate containers are being spawned from inside each other, accessing the host docker engine.

* The cronjob runs inside the `scheduler` container, as seen in this PR.

* The `trigger-deploy-notebook` script (that was previously deployed at `/etc/cron.hourly/PAVICS-deploy-notebooks`) runs inside its own container `notebookdeploy`, as seen in this PR.

* The `trigger-deploy-notebook` also spawn another container `deploy_tutorial_notebooks`, not seen in this PR since it's existing code 
https://github.com/bird-house/birdhouse-deploy/blob/3ae6c14fc5888155fc37655287d3e6c3c29e2e4e/birdhouse/deployment/trigger-deploy-notebook#L88-L95

* Logging still goes to the same `/var/log/PAVICS/notebookdeploy.log` on the docker host as before.