### PR TITLE
jupyter: update to pavics/workflow-tests:200309 to add regionmask and salem for Era5 Raven notebooks

### DIFF
--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -1,7 +1,7 @@
 # All env this common.env can be overridden by env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200120"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200309"
 
 # Folder on the host to persist Jupyter user data (noteboooks, HOME settings)
 export JUPYTERHUB_USER_DATA_DIR="/data/jupyterhub_user_data"


### PR DESCRIPTION
This is the matching PR that will deploy the new Jupyter env to PAVICS.  @huard if you merge this PR, it will autodeploy tomorrow.

See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/36
or commit
https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/f916beadf8f9056e76ed88a52bdfb221c3ee7fb8

jupyter_bokeh (the extension, not the package) was removed due to this issue https://github.com/bokeh/jupyter_bokeh/issues/93

Era5 Raven notebook PR: https://github.com/Ouranosinc/raven/pull/200

Noticeable  rather large Jupyter env changes:

```diff
<   - birdy=v0.6.5=py_0
>   - birdy=v0.6.6=py_0

<   - bokeh=1.4.0=py36_0
>     - bokeh==2.0.0  # from pip recursive dependencies (we get newer version by not explicitly get from conda !)

<   - esgf-compute-api=2.2.1=py_2
>   - esgf-compute-api=2.2.3=py_0

<   - jupyterlab=1.2.5=py_0
>   - jupyterlab=2.0.1=py_0

<   - owslib=0.19.0=py_2
>   - owslib=0.19.1=py_0

<   - pandas=0.25.3=py36hb3f55d8_0
>   - pandas=1.0.1=py37hb3f55d8_0

<   - python=3.6.7=h357f687_1006
>   - python=3.7.6=h357f687_4_cpython

>   - regionmask=0.5.0=py_1

<   - xarray=0.14.1=py_1
>   - xarray=0.15.0=py_0

<     - dask==2.9.2
>     - dask==2.12.0

>     - salem==0.2.4

<     - xclim==0.13.0
>     - xclim==0.14.0
```

Full conda env export Diff:
[200120-200309-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4309639/200120-200309-conda-env-export.diff.txt)

Full new conda env export:
[200309-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4309640/200309-conda-env-export.yml.txt)