### PR TITLE
Thredds: New "Datasets" top level for NCML files

### DIFF
--- a/birdhouse/config/thredds/catalog.xml.template
+++ b/birdhouse/config/thredds/catalog.xml.template
@@ -13,14 +13,6 @@
         <service name="wms" serviceType="WMS" base="/twitcher/ows/proxy/thredds/wms/" />
     </service>
 
-    <service name="ncmlservice" serviceType="Compound" base="" >
-        <service name="http" serviceType="HTTPServer" base="/twitcher/ows/proxy/thredds/fileServer/" />
-        <service name="odap" serviceType="OpenDAP" base="/twitcher/ows/proxy/thredds/dodsC/" />
-        <service name="ncml" serviceType="NCML" base="/twitcher/ows/proxy/thredds/ncml/"/>
-        <service name="uddc" serviceType="UDDC" base="/twitcher/ows/proxy/thredds/uddc/"/>
-        <service name="iso" serviceType="ISO" base="/twitcher/ows/proxy/thredds/iso/"/>
-    </service>
-
     <datasetScan name="Birdhouse" ID="birdhouse" path="birdhouse" location="/pavics-data">
 
       <metadata inherited="true">
@@ -40,7 +32,7 @@
     <datasetScan name="Datasets" ID="datasets" path="datasets" location="/pavics-ncml">
 
       <metadata inherited="true">
-        <serviceName>ncmlservice</serviceName>
+        <serviceName>all</serviceName>
       </metadata>
 
       <filter>
@@ -52,6 +44,5 @@
       </filter>
 
     </datasetScan>
-
 
 </catalog>

--- a/birdhouse/config/thredds/catalog.xml.template
+++ b/birdhouse/config/thredds/catalog.xml.template
@@ -13,7 +13,7 @@
         <service name="wms" serviceType="WMS" base="/twitcher/ows/proxy/thredds/wms/" />
     </service>
 
-    <service name="ncml" serviceType="Compound" base="" >
+    <service name="ncmlservice" serviceType="Compound" base="" >
         <service name="http" serviceType="HTTPServer" base="/twitcher/ows/proxy/thredds/fileServer/" />
         <service name="odap" serviceType="OpenDAP" base="/twitcher/ows/proxy/thredds/dodsC/" />
         <service name="ncml" serviceType="NCML" base="/twitcher/ows/proxy/thredds/ncml/"/>
@@ -40,7 +40,7 @@
     <datasetScan name="Datasets" ID="datasets" path="datasets" location="/pavics-ncml">
 
       <metadata inherited="true">
-        <serviceName>ncml</serviceName>
+        <serviceName>ncmlservice</serviceName>
       </metadata>
 
       <filter>

--- a/birdhouse/config/thredds/catalog.xml.template
+++ b/birdhouse/config/thredds/catalog.xml.template
@@ -13,6 +13,14 @@
         <service name="wms" serviceType="WMS" base="/twitcher/ows/proxy/thredds/wms/" />
     </service>
 
+    <service name="ncml" serviceType="Compound" base="" >
+        <service name="http" serviceType="HTTPServer" base="/twitcher/ows/proxy/thredds/fileServer/" />
+        <service name="odap" serviceType="OpenDAP" base="/twitcher/ows/proxy/thredds/dodsC/" />
+        <service name="ncml" serviceType="NCML" base="/twitcher/ows/proxy/thredds/ncml/"/>
+        <service name="uddc" serviceType="UDDC" base="/twitcher/ows/proxy/thredds/uddc/"/>
+        <service name="iso" serviceType="ISO" base="/twitcher/ows/proxy/thredds/iso/"/>
+    </service>
+
     <datasetScan name="Birdhouse" ID="birdhouse" path="birdhouse" location="/pavics-data">
 
       <metadata inherited="true">
@@ -32,7 +40,7 @@
     <datasetScan name="Datasets" ID="datasets" path="datasets" location="/pavics-ncml">
 
       <metadata inherited="true">
-        <serviceName>all</serviceName>
+        <serviceName>ncml</serviceName>
       </metadata>
 
       <filter>

--- a/birdhouse/config/thredds/catalog.xml.template
+++ b/birdhouse/config/thredds/catalog.xml.template
@@ -29,4 +29,21 @@
 
     </datasetScan>
 
+    <datasetScan name="Datasets" ID="datasets" path="datasets" location="/pavics-ncml">
+
+      <metadata inherited="true">
+        <serviceName>all</serviceName>
+      </metadata>
+
+      <filter>
+        <include wildcard="*.nc" />
+        <include wildcard="*.ncml" />
+        <include wildcard="*.txt" />
+        <include wildcard="*.md" />
+        <include wildcard="*.rst" />
+      </filter>
+
+    </datasetScan>
+
+
 </catalog>

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -241,6 +241,7 @@ services:
     volumes:
       - thredds_persistence:/usr/local/tomcat/content/thredds
       - /data/datasets:/pavics-data
+      - /data/ncml:/pavics-ncml
       - wps_outputs:/pavics-data/wps_outputs
       - ./config/thredds/catalog.xml:/usr/local/tomcat/content/thredds/catalog.xml:ro
       - ./config/thredds/threddsConfig.xml:/usr/local/tomcat/content/thredds/threddsConfig.xml:ro


### PR DESCRIPTION
http://lvupavics-lvu.pagekite.me/twitcher/ows/proxy/thredds/catalog/datasets/catalog.html (only gridded_obs/nrcan.ncml works on my dev server).

Add a new top-level "Datasets" at the same level as the existing "Birdhouse".

The content of the new top-level comes from `/data/ncml` from the host.  For comparison content of existing "Birdhouse" was coming from `/data/datasets`.

Given it's a new top level, I was able to remove WCS and WMS links, now thinking more about this ... I am not sure anymore if I should do this, suggestions?

We should also document somewhere this new "Datasets" top level is for NCML files and regular `.nc` files are still under "Birdhouse".  Let me know where to modify the doc.