### PR TITLE
Jupyter: make configurable public demo user name, passwd, resource limit, login banner

### DIFF
--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -60,7 +60,7 @@ postgres instance. See [`scripts/create-wps-pgsql-databases.sh`](scripts/create-
 * Click "Save".
 
 
-### Create `public` user in Magpie for JupyterHub login
+### Create public demo user in Magpie for JupyterHub login
 
 * Go to
   https://<PAVICS_FQDN>/magpie/ui/login, login with the `admin` user,
@@ -69,9 +69,9 @@ postgres instance. See [`scripts/create-wps-pgsql-databases.sh`](scripts/create-
 * Then go to https://<PAVICS_FQDN>/magpie/ui/users/add
 
 * Fill in:
-  * User name: `public`
+  * User name: <value of JUPYTER_DEMO_USER in `env.local`>
   * Email: anything is fine
-  * Password: `public`
+  * Password: < you decide >
   * User group: `anonymous`
 
 * Click "Add User".

--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -13,5 +13,9 @@ export JUPYTER_DEMO_USER_MEM_LIMIT="2G"  # ex: 2G, 500M
 # CPU limit seems not honored by DockerSpawner
 export JUPYTER_DEMO_USER_CPU_LIMIT="0.5"  # 50% of 1 CPU
 
+# See config/jupyterhub/custom_templates/login.html.template
+export JUPYTER_LOGIN_BANNER_TOP_SECTION=""
+export JUPYTER_LOGIN_BANNER_BOTTOM_SECTION=""
+
 # Folder inside "proxy" container to drop extra monitoring config
 export CANARIE_MONITORING_EXTRA_CONF_DIR="/conf.d"

--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -8,6 +8,10 @@ export JUPYTERHUB_USER_DATA_DIR="/data/jupyterhub_user_data"
 
 # Jupyter public demo account with limited computing resources for security reasons
 export JUPYTER_DEMO_USER="demo"
+# Changing any limits requires restarting the jupyter user server
+export JUPYTER_DEMO_USER_MEM_LIMIT="2G"  # ex: 2G, 500M
+# CPU limit seems not honored by DockerSpawner
+export JUPYTER_DEMO_USER_CPU_LIMIT="0.5"  # 50% of 1 CPU
 
 # Folder inside "proxy" container to drop extra monitoring config
 export CANARIE_MONITORING_EXTRA_CONF_DIR="/conf.d"

--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -6,5 +6,8 @@ export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200312"
 # Folder on the host to persist Jupyter user data (noteboooks, HOME settings)
 export JUPYTERHUB_USER_DATA_DIR="/data/jupyterhub_user_data"
 
+# Jupyter public demo account with limited computing resources for security reasons
+export JUPYTER_DEMO_USER="demo"
+
 # Folder inside "proxy" container to drop extra monitoring config
 export CANARIE_MONITORING_EXTRA_CONF_DIR="/conf.d"

--- a/birdhouse/config/jupyterhub/custom_templates/login.html.template
+++ b/birdhouse/config/jupyterhub/custom_templates/login.html.template
@@ -1,5 +1,7 @@
 {% extends "templates/login.html" %} {% set announcement_login = '
 
+${JUPYTER_LOGIN_BANNER_TOP_SECTION}
+
 <p><strong>Public demo login:</strong> ${JUPYTER_DEMO_USER}</p>
 <p>
   Given this public nature, anyone can tamper with your notebooks so please
@@ -29,4 +31,6 @@
   This Jupyter instance can restart every day.
   <strong>Long running processes will be killed without notice.</strong>
 </p>
+
+${JUPYTER_LOGIN_BANNER_BOTTOM_SECTION}
 ' %}

--- a/birdhouse/config/jupyterhub/custom_templates/login.html.template
+++ b/birdhouse/config/jupyterhub/custom_templates/login.html.template
@@ -1,14 +1,16 @@
 {% extends "templates/login.html" %} {% set announcement_login = '
 
-<p><strong>Public login:</strong> public/public</p>
+<p><strong>Public demo login:</strong> ${JUPYTER_DEMO_USER}</p>
 <p>
   Given this public nature, anyone can tamper with your notebooks so please
   <strong>export your valuable notebooks elsewhere</strong> if you want to
-  preverve them.
+  preverve them.  This public demo account also have limitted computing
+  resources.
 </p>
 <p>
   Contact <strong>${SUPPORT_EMAIL}</strong> for information on how to
-  <strong>get an account and a private workspace</strong>.
+  <strong>get an account and a private workspace or the password of the
+  public demo account</strong>.
 </p>
 <p>
   The only writable folder is <strong>writable-workspace</strong>
@@ -18,6 +20,10 @@
 <p>
   Please <strong>be considerate</strong> with the amount of
   <strong>disk space usage</strong> on this Jupyter instance.
+</p>
+<p>
+  Please <strong>shutdown the kernel</strong> and <strong>close un-used
+  notebooks</strong> to avoid wasting computing resources.
 </p>
 <p>
   This Jupyter instance can restart every day.

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -62,8 +62,9 @@ def create_dir_hook(spawner):
 
     if username == os.environ['JUPYTER_DEMO_USER']:
         # Restrict resources for the public demo user
-        spawner.cpu_limit = 0.25  # 25% of 1 CPU, seems not honored by DockerSpawner
-        spawner.mem_limit = "500M"  # 500 MB
+        # CPU limit, seems not honored by DockerSpawner
+        spawner.cpu_limit = float(os.environ['JUPYTER_DEMO_USER_CPU_LIMIT'])
+        spawner.mem_limit = os.environ['JUPYTER_DEMO_USER_MEM_LIMIT']
 
 c.Spawner.pre_spawn_hook = create_dir_hook
 

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -60,8 +60,8 @@ def create_dir_hook(spawner):
 
     subprocess.call(["chown", "-R", "1000:1000", user_dir])
 
-    if username == 'public':
-        # Restrict resources for the public user
+    if username == os.environ['JUPYTER_DEMO_USER']:
+        # Restrict resources for the public demo user
         spawner.cpu_limit = 0.25  # 25% of 1 CPU, seems not honored by DockerSpawner
         spawner.mem_limit = "500M"  # 500 MB
 

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -350,6 +350,8 @@ services:
       JUPYTERHUB_USER_DATA_DIR: ${JUPYTERHUB_USER_DATA_DIR}
       JUPYTERHUB_ADMIN_USERS: ${JUPYTERHUB_ADMIN_USERS}
       JUPYTER_DEMO_USER: ${JUPYTER_DEMO_USER}
+      JUPYTER_DEMO_USER_MEM_LIMIT: ${JUPYTER_DEMO_USER_MEM_LIMIT}
+      JUPYTER_DEMO_USER_CPU_LIMIT: ${JUPYTER_DEMO_USER_CPU_LIMIT}
     volumes:
       - ./config/jupyterhub/jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro
       - ./config/jupyterhub/custom_templates:/custom_templates:ro

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -349,6 +349,7 @@ services:
       DOCKER_NETWORK_NAME: jupyterhub_network
       JUPYTERHUB_USER_DATA_DIR: ${JUPYTERHUB_USER_DATA_DIR}
       JUPYTERHUB_ADMIN_USERS: ${JUPYTERHUB_ADMIN_USERS}
+      JUPYTER_DEMO_USER: ${JUPYTER_DEMO_USER}
     volumes:
       - ./config/jupyterhub/jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro
       - ./config/jupyterhub/custom_templates:/custom_templates:ro

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -137,6 +137,9 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # Set to 'false' if using self-signed SSL certificate
 #export VERIFY_SSL="true"
 
+# Jupyter public demo account with limited computing resources for security reasons
+#export JUPYTER_DEMO_USER="demo"
+
 #############################################################################
 # Emu optional vars
 #############################################################################

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -142,6 +142,11 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # Changing any limits requires restarting the jupyter user server
 #export JUPYTER_DEMO_USER_MEM_LIMIT="2G"  # ex: 2G, 500M
 
+# See config/jupyterhub/custom_templates/login.html.template
+#export JUPYTER_LOGIN_BANNER_TOP_SECTION=""
+#export JUPYTER_LOGIN_BANNER_BOTTOM_SECTION=""
+
+
 #############################################################################
 # Emu optional vars
 #############################################################################

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -139,6 +139,8 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 
 # Jupyter public demo account with limited computing resources for security reasons
 #export JUPYTER_DEMO_USER="demo"
+# Changing any limits requires restarting the jupyter user server
+#export JUPYTER_DEMO_USER_MEM_LIMIT="2G"  # ex: 2G, 500M
 
 #############################################################################
 # Emu optional vars

--- a/birdhouse/pavics-compose.sh
+++ b/birdhouse/pavics-compose.sh
@@ -40,6 +40,8 @@ OPTIONAL_VARS='
   $MAGPIE_DB_NAME
   $VERIFY_SSL
   $JUPYTER_DEMO_USER
+  $JUPYTER_LOGIN_BANNER_TOP_SECTION
+  $JUPYTER_LOGIN_BANNER_BOTTOM_SECTION
 '
 
 # we switch to the real directory of the script, so it still works when used from $PATH

--- a/birdhouse/pavics-compose.sh
+++ b/birdhouse/pavics-compose.sh
@@ -39,6 +39,7 @@ OPTIONAL_VARS='
   $GITHUB_CLIENT_SECRET
   $MAGPIE_DB_NAME
   $VERIFY_SSL
+  $JUPYTER_DEMO_USER
 '
 
 # we switch to the real directory of the script, so it still works when used from $PATH

--- a/birdhouse/scripts/migrate-jupyterhub-user-persistence
+++ b/birdhouse/scripts/migrate-jupyterhub-user-persistence
@@ -8,8 +8,6 @@ THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
 COMPOSE_DIR="`dirname "$THIS_DIR"`"
 
-PUBLIC_USERNAME="public"
-
 # Default JUPYTERHUB_USER_DATA_DIR
 . $COMPOSE_DIR/common.env
 
@@ -17,6 +15,8 @@ if [ -e "$COMPOSE_DIR/env.local" ]; then
     # Optional override JUPYTERHUB_USER_DATA_DIR
     . $COMPOSE_DIR/env.local
 fi
+
+PUBLIC_USERNAME="$JUPYTER_DEMO_USER"
 
 BASE_CMD="docker run -it --rm --name migrate_jupyterhub_user_persistence \
     -u root \

--- a/docs/source/notebooks/README.ipynb
+++ b/docs/source/notebooks/README.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "These servers are intended to be accessed through a programming environment. More precisely, analytical services can be accessed through a Web Processing Services (WPS) Application programming interface (API). To facilitate the integration of these WPS processes into typical scientific workflows, we suggest using the high-level Python client library (`birdy.WPSClient`). \n",
     "\n",
-    "The `public` demo account on this JupyterLab is not meant as a production environment. It is a public account with no private directory and limited computing resources. Your files are public, can be seen by the rest of the world and can be reset at anytime. Use it to explore the system's capability and see whether it may be useful to your work.\n",
+    "The public demo account on the login page of this JupyterLab is not meant as a production environment. It is a public account with no private directory and limited computing resources. Your files are public, can be seen by the rest of the world and can be reset at anytime. Use it to explore the system's capability and see whether it may be useful to your work.\n",
     "\n",
     "You can request personal account by contacting the email on the login page.  With a personal account, you will have a production environment with private workspace and no computing resource limitation.\n",
     "\n",
@@ -234,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For security reasons, the public demo username and password are not hardcoded anymore.

Compromising of one PAVICS deployment should not compromise all other PAVICS deployments if each deployment use a different password.

The password is set when the public demo user is created in Magpie, see the `birdhouse/README.md` update.

The login banner do not display the public demo password anymore.  If one really want to display the password, can use the top or bottom section of the login banner that is customizable via `env.local`.

Login banner is updated with more notices, please review wording.

Resource limits (only memory limit seems to work with the `DockerSpawner`) is also customizable.

All changes to `env.local` are live after a `./pavics-compose.sh up -d`.

Test server: https://lvupavics-lvu.pagekite.me/jupyter/ (ask me privately for the password :D)

