### PR TITLE
Allow components to be from other extra repos and add Emu to Canarie monitoring

### DIFF
--- a/birdhouse/optional-components/emu/.gitignore
+++ b/birdhouse/optional-components/emu/.gitignore
@@ -1,3 +1,4 @@
 wps.cfg
 emu-magpie-permission.cfg
 emu-magpie-provider.cfg
+emu_canarie_api_monitoring.py

--- a/birdhouse/optional-components/emu/docker-compose-extra.yml
+++ b/birdhouse/optional-components/emu/docker-compose-extra.yml
@@ -17,3 +17,7 @@ services:
     volumes:
     - ./optional-components/emu/emu-magpie-permission.cfg:/opt/local/src/magpie/config/permissions/emu-magpie-permission.cfg:ro
     - ./optional-components/emu/emu-magpie-provider.cfg:/opt/local/src/magpie/config/providers/emu-magpie-provider.cfg:ro
+
+  proxy:
+    volumes:
+    - ./optional-components/emu/emu_canarie_api_monitoring.py:${CANARIE_MONITORING_EXTRA_CONF_DIR}/emu_canarie_api_monitoring.py:ro

--- a/birdhouse/optional-components/emu/emu_canarie_api_monitoring.py.template
+++ b/birdhouse/optional-components/emu/emu_canarie_api_monitoring.py.template
@@ -1,0 +1,14 @@
+SERVICES['node']['monitoring'].update({
+    'Emu-public': {
+        'request': {
+            'url': 'https://${PAVICS_FQDN_PUBLIC}/${TWITCHER_PROTECTED_PATH}/emu?service=WPS&version=1.0.0&request=GetCapabilities'
+        },
+    },
+    'Emu': {
+        'request': {
+            'url': 'http://${PAVICS_FQDN}:8888/wps?service=WPS&version=1.0.0&request=GetCapabilities'
+        }
+    },
+})
+
+# vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4 syntax=python

--- a/birdhouse/pavics-compose.sh
+++ b/birdhouse/pavics-compose.sh
@@ -112,7 +112,7 @@ if [ -z "$VERIFY_SSL" ]; then
 fi
 
 # we apply all the templates
-find ./config ./optional-components -name '*.template' -print0 |
+find ./config ./optional-components $EXTRA_CONF_DIRS -name '*.template' -print0 |
   while IFS= read -r -d $'\0' FILE
   do
     DEST=${FILE%.template}


### PR DESCRIPTION
Allow to have components that are in a completely separate repo (ex: thunderbird from @nikola-rados) to hook into our PAVICS stack without any code change.  Useful for new birds to test compatibility/integration with PAVICS stack early on in their development cycle.

The architecture was already ready for it, just missing template expansion to be performed on those extra repos.

Just realized Canarie monitoring can be "hooked" in as well, after my work in PR https://github.com/bird-house/birdhouse-deploy/pull/22 so I enable it for Emu for demo.

Tested with both Emu and Thunderbird in our PAVICS stack on my dev server: https://lvupavics-lvu.pagekite.me/canarie/node/service/status
![Screenshot_2020-03-30 Ouranos - Node Service](https://user-images.githubusercontent.com/11966697/77978648-982be900-72d0-11ea-85dd-6d2d50816e40.png)
