### PR TITLE
proxy: allow other extra components to extend Nginx

### DIFF
--- a/birdhouse/config/proxy/conf.d/all-services.include.template
+++ b/birdhouse/config/proxy/conf.d/all-services.include.template
@@ -90,3 +90,5 @@
         return 302 ${DOC_URL};
     }
 
+    # for other extra components to extend Nginx
+    include /etc/nginx/conf.extra-service.d/*/*.conf;

--- a/birdhouse/config/proxy/nginx.conf
+++ b/birdhouse/config/proxy/nginx.conf
@@ -32,5 +32,8 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
 
+    # for other extra components to extend Nginx
+    include /etc/nginx/conf.extra.d/*/*.conf;
+
 }
 


### PR DESCRIPTION
@tlogan2000 @huard needed for a new test Thredds container for testing Ncml.

Nginx will load 2 extra dirs for extending the services and general
Nginx config.

Dir mount means adding new files is trivial and should refresh update
safer than each file mount.

Sample usage:

```
services:
  proxy:
    volumes:
    - ../../custom-config/proxy/conf.extra-service.d/testthredds:/etc/nginx/conf.extra-service.d/testthredds:ro
    - ../../custom-config/proxy/conf.extra.d/genericconfig:/etc/nginx/conf.extra.d/genericconfig:ro
```