### PR TITLE
optional-components: testthredds: 2nd Thredds server for testing purposes

### DIFF
--- a/birdhouse/optional-components/README.md
+++ b/birdhouse/optional-components/README.md
@@ -26,3 +26,23 @@ How to enable Emu in `env.local` (a copy from
 Emu service will be available at `http://PAVICS_FQDN:8888/wps` or
 `https://PAVICS_FQDN_PUBLIC/twitcher/ows/proxy/emu` where `PAVICS_FQDN`
 and `PAVICS_FQDN_PUBLIC` are defined in your `env.local`.
+
+
+## A second Thredds server for testing
+
+How to enable in `env.local` (a copy from
+[`env.local.example`](../env.local.example)):
+
+* Add `./optional-components/testthredds` to `EXTRA_CONF_DIRS`.
+
+Test Thredds service will be available at `http://PAVICS_FQDN:8084/testthredds`
+or `https://PAVICS_FQDN_PUBLIC/testthredds` where `PAVICS_FQDN` and
+`PAVICS_FQDN_PUBLIC` are defined in your `env.local`.
+
+New container have new `TestDatasets` with volume-mount to `/data/testdatasets`
+on the host.  So your testing `.nc` and `.ncml` files should be added to
+`/data/testdatasets` on the host for them to show up on this Test Thredds
+server.
+
+No Twitcher/Magpie access control, this Test Thredds is directly behind the
+Nginx proxy.

--- a/birdhouse/optional-components/README.md
+++ b/birdhouse/optional-components/README.md
@@ -45,7 +45,9 @@ on the host.  So your testing `.nc` and `.ncml` files should be added to
 server.
 
 `TestWps_Output` dataset is for other WPS services to write to, similar to
-`birdhouse/wps_outputs` dataset in the production Thredds.
+`birdhouse/wps_outputs` dataset in the production Thredds.  With Emu, add
+`export EMU_WPS_OUTPUTS_VOL=testwps_outputs` to `env.local` for Emu to write to
+`TestWps_Output` dataset.
 
 No Twitcher/Magpie access control, this Test Thredds is directly behind the
 Nginx proxy.

--- a/birdhouse/optional-components/README.md
+++ b/birdhouse/optional-components/README.md
@@ -44,5 +44,8 @@ on the host.  So your testing `.nc` and `.ncml` files should be added to
 `/data/testdatasets` on the host for them to show up on this Test Thredds
 server.
 
+`TestWps_Output` dataset is for other WPS services to write to, similar to
+`birdhouse/wps_outputs` dataset in the production Thredds.
+
 No Twitcher/Magpie access control, this Test Thredds is directly behind the
 Nginx proxy.

--- a/birdhouse/optional-components/emu/docker-compose-extra.yml
+++ b/birdhouse/optional-components/emu/docker-compose-extra.yml
@@ -9,7 +9,7 @@ services:
       - "8888:5000"
     volumes:
       - ./optional-components/emu/wps.cfg:/wps.cfg
-      - wps_outputs:/data/wpsoutputs
+      - ${EMU_WPS_OUTPUTS_VOL:-wps_outputs}:/data/wpsoutputs
       - /tmp
     restart: always
 

--- a/birdhouse/optional-components/testthredds/.gitignore
+++ b/birdhouse/optional-components/testthredds/.gitignore
@@ -1,0 +1,1 @@
+catalog.xml

--- a/birdhouse/optional-components/testthredds/catalog.xml.template
+++ b/birdhouse/optional-components/testthredds/catalog.xml.template
@@ -29,4 +29,20 @@
 
     </datasetScan>
 
+    <datasetScan name="TestWps_Output" ID="testwps_outputs" path="testwps_outputs" location="/testwps_outputs">
+
+      <metadata inherited="true">
+        <serviceName>all</serviceName>
+      </metadata>
+
+      <filter>
+        <include wildcard="*.nc" />
+        <include wildcard="*.ncml" />
+        <include wildcard="*.txt" />
+        <include wildcard="*.md" />
+        <include wildcard="*.rst" />
+      </filter>
+
+    </datasetScan>
+
 </catalog>

--- a/birdhouse/optional-components/testthredds/catalog.xml.template
+++ b/birdhouse/optional-components/testthredds/catalog.xml.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog name="${THREDDS_ORGANIZATION} TEST Thredds Catalog"
+         xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink" >
+
+    <service name="all" serviceType="Compound" base="" >
+        <service name="http" serviceType="HTTPServer" base="/testthredds/fileServer/" />
+        <service name="odap" serviceType="OpenDAP" base="/testthredds/dodsC/" />
+        <service name="ncml" serviceType="NCML" base="/testthredds/ncml/"/>
+        <service name="uddc" serviceType="UDDC" base="/testthredds/uddc/"/>
+        <service name="iso" serviceType="ISO" base="/testthredds/iso/"/>
+        <service name="wcs" serviceType="WCS" base="/testthredds/wcs/" />
+        <service name="wms" serviceType="WMS" base="/testthredds/wms/" />
+    </service>
+
+    <datasetScan name="TestDatasets" ID="testdatasets" path="testdatasets" location="/pavics-testdata">
+
+      <metadata inherited="true">
+        <serviceName>all</serviceName>
+      </metadata>
+
+      <filter>
+        <include wildcard="*.nc" />
+        <include wildcard="*.ncml" />
+        <include wildcard="*.txt" />
+        <include wildcard="*.md" />
+        <include wildcard="*.rst" />
+      </filter>
+
+    </datasetScan>
+
+</catalog>

--- a/birdhouse/optional-components/testthredds/conf.extra-service.d/.gitignore
+++ b/birdhouse/optional-components/testthredds/conf.extra-service.d/.gitignore
@@ -1,0 +1,1 @@
+testthredds-service.conf

--- a/birdhouse/optional-components/testthredds/conf.extra-service.d/testthredds-service.conf.template
+++ b/birdhouse/optional-components/testthredds/conf.extra-service.d/testthredds-service.conf.template
@@ -1,0 +1,7 @@
+    location /testthredds/ {
+        # direct hit Thredds, bypassing Twitcher
+        proxy_pass http://testthredds:8080/testthredds/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }

--- a/birdhouse/optional-components/testthredds/docker-compose-extra.yml
+++ b/birdhouse/optional-components/testthredds/docker-compose-extra.yml
@@ -22,6 +22,7 @@ services:
       - /data/testdatasets:/pavics-testdata:ro
       - /data/datasets:/pavics-data:ro
       - /data/ncml:/pavics-ncml:ro
+      - testwps_outputs:/testwps_outputs:ro
       - wps_outputs:/pavics-data/wps_outputs:ro
       - ./optional-components/testthredds/catalog.xml:/usr/local/tomcat/content/thredds/catalog.xml:ro
       - ./config/thredds/threddsConfig.xml:/usr/local/tomcat/content/thredds/threddsConfig.xml:ro
@@ -40,3 +41,4 @@ services:
 
 volumes:
   testthredds_persistence: {}
+  testwps_outputs: {}

--- a/birdhouse/optional-components/testthredds/docker-compose-extra.yml
+++ b/birdhouse/optional-components/testthredds/docker-compose-extra.yml
@@ -1,0 +1,42 @@
+version: '2.1'
+services:
+  proxy:
+    volumes:
+    - ./optional-components/testthredds/conf.extra-service.d:/etc/nginx/conf.extra-service.d/testthredds:ro
+    links:
+    - testthredds
+
+  testthredds:
+    image: unidata/thredds-docker:4.6.14
+    container_name: testthredds
+    ports:
+      - "8084:8080"
+    env_file:
+      - ./config/thredds/thredds.env
+    environment:
+      # for reconstructing proper URL back to user when Thredds behind proxy
+      # because Twitcher eats the "Host" http header set by Nginx
+      PAVICS_FQDN_PUBLIC: $PAVICS_FQDN_PUBLIC
+    volumes:
+      - testthredds_persistence:/usr/local/tomcat/content/thredds
+      - /data/testdatasets:/pavics-testdata:ro
+      - /data/datasets:/pavics-data:ro
+      - /data/ncml:/pavics-ncml:ro
+      - wps_outputs:/pavics-data/wps_outputs:ro
+      - ./optional-components/testthredds/catalog.xml:/usr/local/tomcat/content/thredds/catalog.xml:ro
+      - ./config/thredds/threddsConfig.xml:/usr/local/tomcat/content/thredds/threddsConfig.xml:ro
+      - ./config/thredds/wmsConfig.xml:/usr/local/tomcat/content/thredds/wmsConfig.xml:ro
+      - ./optional-components/testthredds/entrypointwrapper:/entrypointwrapper:ro
+    entrypoint: /entrypointwrapper
+    restart: always
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "--fail",
+          "http://localhost:8080/testthredds/catalog.html",
+        ]
+
+volumes:
+  testthredds_persistence: {}

--- a/birdhouse/optional-components/testthredds/entrypointwrapper
+++ b/birdhouse/optional-components/testthredds/entrypointwrapper
@@ -1,0 +1,33 @@
+#!/bin/sh -x
+
+CONF_FILE="/usr/local/tomcat/conf/server.xml"
+
+if ! grep ' relaxedQueryChars=' $CONF_FILE; then
+    # allow angle bracket in query params, ex:
+    # https://boreas.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/tasmax_day_BCCAQv2+ANUSPLIN300_BNU-ESM_historical+rcp85_r1i1p1_19500101-21001231.nc.ascii?tasmax[0:1:0][0:1:0][0:1:0]
+    cp -v $CONF_FILE ${CONF_FILE}.bak.relaxedQueryChars.$$
+    sed -i 's/<Connector /<Connector relaxedQueryChars="[,]" /g' $CONF_FILE
+fi
+
+if ! grep " scheme=\"https\" proxyName=\"${PAVICS_FQDN_PUBLIC}\" proxyPort=\"443\" " $CONF_FILE; then
+    # force https because Thredds do not seems to handle X-Forwarded-Proto correctly
+    cp -v $CONF_FILE ${CONF_FILE}.bak.scheme.$$
+    sed -i "s/<Connector /<Connector scheme=\"https\" proxyName=\"${PAVICS_FQDN_PUBLIC}\" proxyPort=\"443\" /g" $CONF_FILE
+fi
+
+
+# change displayed context-root to under twitcher
+# https://www.unidata.ucar.edu/software/tds/v4.6/reference/TomcatBehindProxyServer.html
+WEBAPPS_ROOT="/usr/local/tomcat/webapps"
+EXISTING_CONTEXT_ROOT="thredds"
+WANTED_CONTEXT_ROOT="testthredds"
+WANTED_CONTEXT_ROOT_WARFILE_NAME="testthredds"
+
+if [ -d "$WEBAPPS_ROOT/$EXISTING_CONTEXT_ROOT" ]; then
+    mv "$WEBAPPS_ROOT/$EXISTING_CONTEXT_ROOT" "$WEBAPPS_ROOT/$WANTED_CONTEXT_ROOT_WARFILE_NAME"
+    sed -i "s@<param-value>$EXISTING_CONTEXT_ROOT</param-value>@<param-value>$WANTED_CONTEXT_ROOT</param-value>@g" "$WEBAPPS_ROOT/$WANTED_CONTEXT_ROOT_WARFILE_NAME/WEB-INF/web.xml"
+fi
+
+
+# chain existing entrypoint
+/entrypoint.sh catalina.sh run


### PR DESCRIPTION
Here's the configs for the new testthredds, as an optional component obviously.

Not sure why I've put it in our private config earlier, there's nothing private about this.

Having it here will illustrate/demo the use-case for my earlier PR https://github.com/bird-house/birdhouse-deploy/pull/37 (commit https://github.com/bird-house/birdhouse-deploy/commit/4851a4709327e397b8f4c44ba06f8ea4cf922aa0).

The `REAME.md` changes have more infos.