### PR TITLE
finch: update to 0.5.2

### DIFF
--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -151,7 +151,7 @@ services:
     restart: always
 
   finch:
-    image: birdhouse/finch:version-0.5.1
+    image: birdhouse/finch:version-0.5.2
     container_name: finch
     environment:
       HOSTNAME: $HOSTNAME


### PR DESCRIPTION
Fix following 2 Jenkins failures:

Tested in this Jenkins run http://jenkins.ouranos.ca/job/ouranos-staging/job/lvupavics-lvu.pagekite.me/20/console

```
  _________ finch-master/docs/source/notebooks/dap_subset.ipynb::Cell 9 __________
  Notebook cell execution failed
  Cell 9: Cell outputs differ

  Input:
  resp = wps.sdii(pr + sub)
  out = resp.get(asobj=True)
  out.output_netcdf.sdii

  Traceback:
   mismatch 'text/html'

   assert reference_output == test_output failed:

    '<pre>&lt;xar...vera...</pre>' == '<pre>&lt;xar...vera...</pre>'
    Skipping 350 identical leading characters in diff, use -v to show
      m/day
    -     cell_methods:   time: mean (interval: 30 minutes)
          history:        pr=max(0,pr) applied to raw data;\n[DATE_TIME] ...
    +     cell_methods:   time: mean (interval: 30 minutes)
          standard_name:  lwe_thickness_of_precipitation_amount
          long_name:      Average precipitation during wet days (sdii)
          description:    Annual simple daily intensity index (sdii) : annual avera...</pre>
```

```
  _________ finch-master/docs/source/notebooks/finch-usage.ipynb::Cell 1 _________
  Notebook cell execution failed
  Cell 1: Cell outputs differ

  Input:
  help(wps.frost_days)

  Traceback:
   mismatch 'stdout'

   assert reference_output == test_output failed:

    'Help on meth...ut files.\n\n' == 'Help on meth...ut files.\n\n'
    Skipping 399 identical leading characters in diff, use -v to show
    -    freq : string
    +    freq : {'YS', 'MS', 'QS-DEC', 'AS-JUL'}string
              Resampling frequency

          Returns
          -------
          output_netcdf : ComplexData:mimetype:`application/x-netcdf`
              The indicator values computed on the original input grid.
          output_log : ComplexData:mimetype:`text/plain`
              Collected logs during process run.
          ref : ComplexData:mimetype:`application/metalink+xml; version=4.0`
              Metalink file storing all references to output files.
```