### PR TITLE
vagrant: add centos7 and LetsEncrypt SSL cert support, fix scheduler autodeploy remaining issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision :shell, path: "birdhouse/vagrant-utils/provision.sh", env: {"VM_HOSTNAME" => settings['hostname'],
                                                                                   "VM_DOMAIN" => settings['domain'],
+                                                                                  "LETSENCRYPT_EMAIL" => settings['letsencrypt_email'],
                                                                                   "KITENAME" => settings.fetch('kitename',''),
                                                                                   "KITESECRET" => settings.fetch('kitesecret',''),
                                                                                   "KITESUBDOMAIN" => settings.fetch('kitesubdomain',''),

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ settings=YAML.load_file(config_file)
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = ["vagrant-disksize", "vagrant-vbguest"]
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = settings.fetch('box', "ubuntu/bionic64")
   config.vm.define settings['hostname']
   config.vm.hostname = settings['hostname']
   # thin provisioning, won't take 100G upfront

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,10 @@ Vagrant.configure("2") do |config|
   # 2019-07-03 with VirtualBox 6.0.8
   config.vbguest.auto_update = false
 
+  # https://blog.centos.org/2018/01/updated-centos-vagrant-images-available-v1801-01/
+  # Fix /vagrant shared folders (together with vagrant-vbguest) for Centos 7.
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+
   # bridge networking to get real DNS name on local network, PAVICS does not
   # seems to work with numerical IP address for PAVICS_FQDN
   if settings.has_key?('hostip')

--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -33,6 +33,16 @@ automated continuous deployment.  See the continuous deployment setup section
 below and the variable `AUTODEPLOY_EXTRA_REPOS` in
 [`env.local.example`](env.local.example).
 
+The automatic deployment of the PAVICS platform, of the Jupyter tutorial
+notebooks and of the automatic deployment mechanism itself can all be
+enabled and configured in the `env.local` file (a copy from
+[`env.local.example`](env.local.example)).
+
+* Add `./components/scheduler` to `EXTRA_CONF_DIRS`.
+* Set `AUTODEPLOY_EXTRA_REPOS`, `AUTODEPLOY_DEPLOY_KEY_ROOT_DIR`,
+  `AUTODEPLOY_PLATFORM_FREQUENCY`, `AUTODEPLOY_NOTEBOOK_FREQUENCY` as
+  desired, full documentation in [`env.local.example`](env.local.example).
+
 To launch all the containers, use the following command:
 ```
 ./pavics-compose.sh up -d
@@ -78,6 +88,12 @@ postgres instance. See [`scripts/create-wps-pgsql-databases.sh`](scripts/create-
 
 
 ## Mostly automated unattended continuous deployment
+
+***NOTE***: this section about automated unattended continuous deployment is
+superseded by the new `./components/scheduler` that can be entirely
+enabled/disabled via the `env.local` file.  See the part about automatic
+deployment of the PAVICS platform in the "Docker instructions" section
+above for how to configure it.
 
 Automated unattended continuous deployment means if code change in the checkout
 of this repo, on the same currently checkout branch (ex: config changes,

--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -140,7 +140,7 @@ configurable with Vagrant.
 If using Centos box, follow [`disk-resize`](vagrant-utils/disk-resize) after
 first `vagrant up` failure due to disk full.  Then `vagrant reload && vagrant
 provision` to continue.  If using Ubuntu box, no manual steps required,
-everything just work.
+everything just works.
 
 Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads), both the
 platform and the extension pack, and

--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -42,6 +42,7 @@ enabled and configured in the `env.local` file (a copy from
 * Set `AUTODEPLOY_EXTRA_REPOS`, `AUTODEPLOY_DEPLOY_KEY_ROOT_DIR`,
   `AUTODEPLOY_PLATFORM_FREQUENCY`, `AUTODEPLOY_NOTEBOOK_FREQUENCY` as
   desired, full documentation in [`env.local.example`](env.local.example).
+* Run once [`fix-write-perm`](deployment/fix-write-perm), see doc in script.
 
 To launch all the containers, use the following command:
 ```

--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -137,6 +137,11 @@ respective VM, allowing us to see the differences in behavior.
 See [`vagrant_variables.yml.example`](../vagrant_variables.yml.example) for what's
 configurable with Vagrant.
 
+If using Centos box, follow [`disk-resize`](vagrant-utils/disk-resize) after
+first `vagrant up` failure due to disk full.  Then `vagrant reload && vagrant
+provision` to continue.  If using Ubuntu box, no manual steps required,
+everything just work.
+
 Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads), both the
 platform and the extension pack, and
 [Vagrant](https://www.vagrantup.com/downloads.html).

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -38,11 +38,10 @@ c.DockerSpawner.environment = {
 c.DockerSpawner.volumes = {host_user_data_dir: container_workspace_dir}
 
 host_tutorial_notebooks_dir = join(jupyterhub_data_dir, "tutorial-notebooks")
-if os.path.exists(host_tutorial_notebooks_dir):
-    c.DockerSpawner.volumes[host_tutorial_notebooks_dir] = {
-        "bind": join(notebook_dir, "tutorial-notebooks"),
-        "mode": "ro"
-    }
+c.DockerSpawner.volumes[host_tutorial_notebooks_dir] = {
+    "bind": join(notebook_dir, "tutorial-notebooks"),
+    "mode": "ro"
+}
 
 readme = join(jupyterhub_data_dir, "README.ipynb")
 if os.path.exists(readme):

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -7,6 +7,7 @@
 #
 # Useful extra options:
 # * more --domain
+# * --cert-name  # to avoid automatic /etc/letsencrypt/live/DOMAIN-0001 "safe" naming
 # * --staging
 # * --dry-run
 #

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -1,0 +1,61 @@
+#!/bin/sh -e
+# Renew LetsEncrypt SSL certificate using certbot docker image.
+#
+# Important:
+# * SUPPORT_EMAIL from env.local is used as renew email, make sure it's valid!
+# * certbot requires your port 80 and 443 be accessible directly on the internet
+#
+# Useful extra options:
+# * more --domain
+# * --staging
+# * --dry-run
+#
+# Port 80 and 443 must be free at the time of invoking this script
+# (pavics-compose.sh stop proxy)
+
+THIS_FILE="`realpath "$0"`"
+THIS_DIR="`dirname "$THIS_FILE"`"
+
+# Default values
+. $THIS_DIR/../common.env
+
+if [ -e "$THIS_DIR/../env.local" ]; then
+    # Override default values
+    . $THIS_DIR/../env.local
+fi
+
+set -x
+
+CERT_DOMAIN="$PAVICS_FQDN_PUBLIC"
+if [ -z "$CERT_DOMAIN" ]; then
+    CERT_DOMAIN="$PAVICS_FQDN"
+fi
+
+docker run --rm --name certbot \
+  -v "/etc/letsencrypt:/etc/letsencrypt" \
+  -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
+  -v "/var/log/letsencrypt:/var/log/letsencrypt" \
+  -p 443:443 -p 80:80 \
+  certbot/certbot:v1.3.0 \
+  certonly \
+  --non-interactive \
+  --agree-tos \
+  --no-eff-email \
+  --standalone \
+  --email $SUPPORT_EMAIL \
+  --domain $CERT_DOMAIN \
+  "$@"
+RC=$?
+
+set +x
+echo "
+What to do next:
+
+CERTPATH=\"/etc/letsencrypt/live/$CERT_DOMAIN\"
+cd $THIS_DIR/..
+sudo cat \$CERTPATH/fullchain.pem \$CERTPATH/privkey.pem > $SSL_CERTIFICATE
+openssl x509 -noout -text -in $SSL_CERTIFICATE
+./pavics-compose.sh up -d
+"
+
+exit $RC

--- a/birdhouse/deployment/fix-write-perm
+++ b/birdhouse/deployment/fix-write-perm
@@ -1,0 +1,52 @@
+#!/bin/sh -e
+# Fix write permission lost due to files owned by root user.
+#
+# Run once for this repo and once each time AUTODEPLOY_EXTRA_REPOS changes.
+#
+# The 'autodeploy' container spawned by the 'scheduler' container runs as
+# user root.  It writes to all the git checkout in AUTODEPLOY_EXTRA_REPOS
+# and the current birdhouse-deploy checkout as well.  All the new files
+# created will be owned by the root user.
+#
+# Running those setfacl commands will allow the current user to retain
+# write access to all the new files owned by root user.
+#
+# Other options considered but discarded:
+#
+# * running docker run -u current-uid:current-gid: this involve a
+# pre-existing user in the container matching the current local user and
+# local docker group id, which means this solution is not portable.
+#
+# * on the fly creation of a user with proper uid/gid and member of local
+# docker gid then 'su' to that user to run the autodeploy: this is more
+# complex and we lose all the environment var that given to the initial
+# root user.
+#
+# * use docker user namespace
+# (https://docs.docker.com/engine/security/userns-remap/): this is a
+# global configuration for the docker deamon that impacts all containers
+# on the same host (we only need for the 'autodeploy' container).  Not
+# portable if a host is used to run other services than PAVICS, we do not
+# want to force all other services to the same owner as PAVICS checkout.
+#
+# So the setfacl solution is the simplest, most portable/generic and most
+# localized (only the directories we need) solution.
+
+THIS_FILE="`realpath "$0"`"
+THIS_DIR="`dirname "$THIS_FILE"`"
+
+# Go to repo root.
+cd $THIS_DIR/../..
+
+# Default values
+. birdhouse/common.env
+
+if [ -e "birdhouse/env.local" ]; then
+    # Override default values
+    . birdhouse/env.local
+fi
+
+set -x
+
+sudo setfacl -Rdm u:$USER:rwX $PWD $AUTODEPLOY_EXTRA_REPOS  # for future files
+sudo setfacl -Rm u:$USER:rwX $PWD $AUTODEPLOY_EXTRA_REPOS  # for existing files

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -78,6 +78,9 @@ cat << __EOF__ > $TMP_SCRIPT
 
 cd $NOTEBOOK_DIR_MNT
 rm -rf $TUTORIAL_NOTEBOOKS_DIR/*
+if [ ! -d $TUTORIAL_NOTEBOOKS_DIR ]; then
+  mkdir $TUTORIAL_NOTEBOOKS_DIR
+fi
 cp -rv /$TUTORIAL_NOTEBOOKS_DIR/* $TUTORIAL_NOTEBOOKS_DIR
 # make read-only
 chown -R root:root $TUTORIAL_NOTEBOOKS_DIR

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -67,9 +67,15 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # Useful to save the instanciated version of this env.local config file and
 # any custom docker-compose-extra.yml from the previous EXTRA_CONF_DIRS var.
 #
-# Note: these extra repos should be git repos for the out-of-date detection to
+# Note:
+#
+# * These extra repos should be git repos for the out-of-date detection to
 # work to trigger autodeploy.  If you just have a regular folder, do not add
 # it here, out-of-date detection currently only works for git repos.
+#
+# * To preserve write permissions for your user, run once for this repo and
+# once each time AUTODEPLOY_EXTRA_REPOS changes:
+#     deployment/fix-write-perm
 #
 # Format: space separated list of full path to dirs
 #export AUTODEPLOY_EXTRA_REPOS="/path/to/dir1 /path/to/dir2 /path/to/dir3"

--- a/birdhouse/vagrant-utils/configure-pagekite
+++ b/birdhouse/vagrant-utils/configure-pagekite
@@ -4,7 +4,12 @@ ACCOUNT_CONF="/etc/pagekite.d/10_account.rc"
 
 if [ -n "$KITENAME" -a -n "$KITESECRET" -a -n "$KITESUBDOMAIN" ]; then
 
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes pagekite
+    if ! grep centos /etc/os-release; then
+        DEBIAN_FRONTEND=noninteractive apt-get install --yes pagekite
+    else
+        yum install --assumeyes epel-release
+        yum install --assumeyes pagekite
+    fi
 
     cat <<EOF | tee "$ACCOUNT_CONF"
 kitename   = $KITENAME
@@ -20,7 +25,18 @@ EOF
 
 else
 
-    if dpkg -l pagekite; then
+    DISABLE_PAGEKITE=""
+    if ! grep centos /etc/os-release; then
+        if dpkg -l pagekite; then
+            DISABLE_PAGEKITE=true
+        fi
+    else
+        if rpm -q pagekite; then
+            DISABLE_PAGEKITE=true
+        fi
+    fi
+
+    if [ -n "$DISABLE_PAGEKITE" ]; then
         systemctl stop pagekite
         systemctl disable pagekite
     fi

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -1,35 +1,48 @@
 #!/bin/sh -x
 
-if [ ! -f certkey.pem ]; then
-    openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem \
-        -subj "/C=CA/ST=Quebec/L=Montreal/O=RnD/CN=${VM_HOSTNAME}.$VM_DOMAIN"
-    cp cert.pem certkey.pem
-    cat key.pem >> certkey.pem
-    USE_SELF_SIGN_SSL="true"
-else
-    echo "existing certkey.pem file, not overriding"
-fi
-
 if [ ! -f env.local ]; then
     cp env.local.example env.local
     cat <<EOF >> env.local
+
 # override with values needed for vagrant
 export SSL_CERTIFICATE='./certkey.pem'  # path to the nginx ssl certificate, path and key bundle
 export PAVICS_FQDN='${VM_HOSTNAME}.$VM_DOMAIN' # Fully qualified domain name of this Pavics installation
 EOF
+    if [ -n "$LETSENCRYPT_EMAIL" ]; then
+    cat <<EOF >> env.local
+export SUPPORT_EMAIL="$LETSENCRYPT_EMAIL"
+EOF
+    fi
+
     if [ -n "$KITENAME" -a -n "$KITESUBDOMAIN" ]; then
     cat <<EOF >> env.local
 export PAVICS_FQDN_PUBLIC="$KITESUBDOMAIN-$KITENAME"
 export ALLOW_UNSECURE_HTTP="True"
 EOF
     fi
-    if [ x"$USE_SELF_SIGN_SSL" = xtrue ]; then
-    cat <<EOF >> env.local
-export VERIFY_SSL="false"
-EOF
-    fi
 else
     echo "existing env.local file, not overriding"
+fi
+
+if [ ! -f certkey.pem ]; then
+    . ./env.local
+    if [ -n "$LETSENCRYPT_EMAIL" ]; then
+        deployment/certbotwrapper --cert-name $PAVICS_FQDN
+        CERTPATH="/etc/letsencrypt/live/$PAVICS_FQDN"
+        sudo cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $SSL_CERTIFICATE
+    else
+        openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem \
+            -subj "/C=CA/ST=Quebec/L=Montreal/O=RnD/CN=${VM_HOSTNAME}.$VM_DOMAIN"
+        cp cert.pem certkey.pem
+        cat key.pem >> certkey.pem
+        if [ -z "$VERIFY_SSL" ]; then
+            cat <<EOF >> env.local
+export VERIFY_SSL="false"
+EOF
+        fi
+    fi
+else
+    echo "existing certkey.pem file, not overriding"
 fi
 
 ./pavics-compose.sh up -d

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -27,6 +27,7 @@ fi
 if [ ! -f certkey.pem ]; then
     . ./env.local
     if [ -n "$LETSENCRYPT_EMAIL" ]; then
+        ./pavics-compose.sh stop proxy
         deployment/certbotwrapper --cert-name $PAVICS_FQDN
         CERTPATH="/etc/letsencrypt/live/$PAVICS_FQDN"
         sudo cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $SSL_CERTIFICATE

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -8,18 +8,18 @@ if [ ! -f env.local ]; then
 export SSL_CERTIFICATE='./certkey.pem'  # path to the nginx ssl certificate, path and key bundle
 export PAVICS_FQDN='${VM_HOSTNAME}.$VM_DOMAIN' # Fully qualified domain name of this Pavics installation
 EOF
+
     if [ -n "$LETSENCRYPT_EMAIL" ]; then
     cat <<EOF >> env.local
 export SUPPORT_EMAIL="$LETSENCRYPT_EMAIL"
 EOF
-    fi
-
-    if [ -n "$KITENAME" -a -n "$KITESUBDOMAIN" ]; then
+    elif [ -n "$KITENAME" -a -n "$KITESUBDOMAIN" ]; then
     cat <<EOF >> env.local
 export PAVICS_FQDN_PUBLIC="$KITESUBDOMAIN-$KITENAME"
 export ALLOW_UNSECURE_HTTP="True"
 EOF
     fi
+
 else
     echo "existing env.local file, not overriding"
 fi

--- a/birdhouse/vagrant-utils/disk-resize
+++ b/birdhouse/vagrant-utils/disk-resize
@@ -1,0 +1,78 @@
+#!/bin/sh -x
+# Manual disk resize procedure for Centos 7 only.
+# Ubuntu vagrant image is able to transparently automate all this.
+
+###
+# WORK-AROUND explanation:
+#
+# fdisk can resize a live mounted partition as long as it's growing only and
+# the start do not change.
+# Basically we delete the partition and recreate a new one at the same start
+# location and ending further.
+# Then reboot and notify the filesystem to take up the new available space.
+###
+
+# Can not use parted on a live mounted partition.
+#sudo parted /dev/sda resizepart 1 100%
+
+# Sample manual fdisk run and output
+#$ sudo fdisk /dev/sda
+#Welcome to fdisk (util-linux 2.23.2).
+#
+#Changes will remain in memory only, until you decide to write them.
+#Be careful before using the write command.
+#
+#
+#Command (m for help): p
+#
+#Disk /dev/sda: 107.4 GB, 107374182400 bytes, 209715200 sectors
+#Units = sectors of 1 * 512 = 512 bytes
+#Sector size (logical/physical): 512 bytes / 512 bytes
+#I/O size (minimum/optimal): 512 bytes / 512 bytes
+#Disk label type: dos
+#Disk identifier: 0x0009ef88
+#
+#   Device Boot      Start         End      Blocks   Id  System
+#/dev/sda1   *        2048    83886079    41942016   83  Linux
+#
+#Command (m for help): d
+#Selected partition 1
+#Partition 1 is deleted
+#
+#Command (m for help): n
+#Partition type:
+#   p   primary (0 primary, 0 extended, 4 free)
+#   e   extended
+#Select (default p): p
+#Partition number (1-4, default 1): 1
+#First sector (2048-209715199, default 2048):
+#Using default value 2048
+#Last sector, +sectors or +size{K,M,G} (2048-209715199, default 209715199):
+#Using default value 209715199
+#Partition 1 of type Linux and of size 100 GiB is set
+#
+#Command (m for help): p
+#
+#Disk /dev/sda: 107.4 GB, 107374182400 bytes, 209715200 sectors
+#Units = sectors of 1 * 512 = 512 bytes
+#Sector size (logical/physical): 512 bytes / 512 bytes
+#I/O size (minimum/optimal): 512 bytes / 512 bytes
+#Disk label type: dos
+#Disk identifier: 0x0009ef88
+#
+#   Device Boot      Start         End      Blocks   Id  System
+#/dev/sda1            2048   209715199   104856576   83  Linux
+#
+#Command (m for help): w
+#The partition table has been altered!
+#
+#Calling ioctl() to re-read partition table.
+#
+#WARNING: Re-reading the partition table failed with error 16: Device or resource busy.
+#The kernel still uses the old table. The new table will be used at
+#the next reboot or after you run partprobe(8) or kpartx(8)
+#Syncing disks.
+
+### Reboot after performing fdisk
+
+sudo xfs_growfs /dev/sda1

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -1,59 +1,72 @@
 #!/usr/bin/env bash
 
-# Install Docker CE on Ubuntu per
-# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/
+# # Install Docker CE on Ubuntu per
+# # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/
+# 
+# # From https://github.com/stefanlasiewski/vagrant-ubuntu-docker/blob/756db1689947b1ba6eb360354bc10150c510a52a/install-docker.sh
+# 
+# set -e # Exit if any subcommand fails
+# set -x # Print commands for troubleshooting
+# 
+# # The Docker version may be specified as $1
+# if [ $# -eq 1 ]; then
+#   docker_version=$1
+# fi
+# 
+# # 1. Update the apt package index:
+# 
+# sudo apt-get --yes --quiet update
+# 
+# # 2. Install packages to allow apt to use a repository over HTTPS:
+# 
+# sudo apt-get --yes --quiet install \
+#     apt-transport-https \
+#     ca-certificates \
+#     curl \
+#     software-properties-common
+# 
+# # 3. Add Docker’s official GPG key:
+# 
+# curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+# 
+# # Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint.
+# 
+# sudo apt-key fingerprint 0EBFCD88
+# 
+# # 4. Use the following command to set up the stable repository. You always need the stable repository, even if you want to install builds from the edge or test repositories as well. To add the edge or test repository, add the word edge or test (or both) after the word stable in the commands below.
+# #DOCKER_REPOS="stable edge"
+# DOCKER_REPOS="stable"
+# 
+# sudo add-apt-repository \
+#    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+#    $(lsb_release -cs) \
+#    $DOCKER_REPOS"
+# 
+# # INSTALL DOCKER CE
+# 
+# # 1. Update the apt package index.
+# 
+# sudo apt-get --yes --quiet update
+# 
+# # 2. Install the latest version of Docker CE, or go to the next step to install a specific version. Any existing installation of Docker is replaced.
+# if [ "$docker_version" ]; then
+#   sudo apt-get install --yes --quiet docker-ce=$docker_version
+# else
+#   sudo apt-get install --yes --quiet docker-ce
+# fi
 
-# From https://github.com/stefanlasiewski/vagrant-ubuntu-docker/blob/756db1689947b1ba6eb360354bc10150c510a52a/install-docker.sh
 
-set -e # Exit if any subcommand fails
-set -x # Print commands for troubleshooting
+sudo yum install -y yum-utils
 
-# The Docker version may be specified as $1
-if [ $# -eq 1 ]; then
-  docker_version=$1
-fi
+sudo yum-config-manager \
+    --add-repo \
+    https://download.docker.com/linux/centos/docker-ce.repo
 
-# 1. Update the apt package index:
+sudo yum install -y docker-ce docker-ce-cli containerd.io
 
-sudo apt-get --yes --quiet update
+sudo systemctl enable docker
+sudo systemctl start docker
 
-# 2. Install packages to allow apt to use a repository over HTTPS:
-
-sudo apt-get --yes --quiet install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    software-properties-common
-
-# 3. Add Docker’s official GPG key:
-
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-
-# Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint.
-
-sudo apt-key fingerprint 0EBFCD88
-
-# 4. Use the following command to set up the stable repository. You always need the stable repository, even if you want to install builds from the edge or test repositories as well. To add the edge or test repository, add the word edge or test (or both) after the word stable in the commands below.
-#DOCKER_REPOS="stable edge"
-DOCKER_REPOS="stable"
-
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   $DOCKER_REPOS"
-
-# INSTALL DOCKER CE
-
-# 1. Update the apt package index.
-
-sudo apt-get --yes --quiet update
-
-# 2. Install the latest version of Docker CE, or go to the next step to install a specific version. Any existing installation of Docker is replaced.
-if [ "$docker_version" ]; then
-  sudo apt-get install --yes --quiet docker-ce=$docker_version
-else
-  sudo apt-get install --yes --quiet docker-ce
-fi
 
 # 4. Verify that Docker CE is installed correctly by running the hello-world image.
 

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -82,6 +82,8 @@ if [ -n "`df -h | grep ^vagrant`" ]; then
     sudo usermod -a -G docker vagrant
 fi
 
+sudo yum install -y git
+
 # install docker-compose, from https://gist.github.com/wdullaer/f1af16bd7e970389bad3
 LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"|tail -1`"
 # LATEST_COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)  # need jq :(

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -89,9 +89,9 @@ if [ -n "`df -h | grep ^vagrant`" ]; then
 fi
 
 # install docker-compose, from https://gist.github.com/wdullaer/f1af16bd7e970389bad3
-LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"|tail -1`"
+LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -v refs/tags/v | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"|tail -1`"
 # LATEST_COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)  # need jq :(
 sudo curl -L "https://github.com/docker/compose/releases/download/$LATEST_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 sudo curl -L "https://raw.githubusercontent.com/docker/compose/${LATEST_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
-
+docker-compose --version

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -88,6 +88,10 @@ if [ -n "`df -h | grep ^vagrant`" ]; then
     sudo usermod -a -G docker vagrant
 fi
 
+# Add /usr/local/bin to PATH of all users, even root user, so docker-compose
+# can be found.
+echo 'export PATH="$PATH:/usr/local/bin"' > /etc/profile.d/usr_local_path.sh
+
 # install docker-compose, from https://gist.github.com/wdullaer/f1af16bd7e970389bad3
 LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -v refs/tags/v | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"|tail -1`"
 # LATEST_COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)  # need jq :(

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -82,7 +82,8 @@ if [ -n "`df -h | grep ^vagrant`" ]; then
     sudo usermod -a -G docker vagrant
 fi
 
-sudo yum install -y git
+# net-tools for 'route' command
+sudo yum install -y git net-tools
 
 # install docker-compose, from https://gist.github.com/wdullaer/f1af16bd7e970389bad3
 LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"|tail -1`"

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -1,77 +1,83 @@
 #!/usr/bin/env bash
 
-# # Install Docker CE on Ubuntu per
-# # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/
-# 
-# # From https://github.com/stefanlasiewski/vagrant-ubuntu-docker/blob/756db1689947b1ba6eb360354bc10150c510a52a/install-docker.sh
-# 
-# set -e # Exit if any subcommand fails
-# set -x # Print commands for troubleshooting
-# 
-# # The Docker version may be specified as $1
-# if [ $# -eq 1 ]; then
-#   docker_version=$1
-# fi
-# 
-# # 1. Update the apt package index:
-# 
-# sudo apt-get --yes --quiet update
-# 
-# # 2. Install packages to allow apt to use a repository over HTTPS:
-# 
-# sudo apt-get --yes --quiet install \
-#     apt-transport-https \
-#     ca-certificates \
-#     curl \
-#     software-properties-common
-# 
-# # 3. Add Docker’s official GPG key:
-# 
-# curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-# 
-# # Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint.
-# 
-# sudo apt-key fingerprint 0EBFCD88
-# 
-# # 4. Use the following command to set up the stable repository. You always need the stable repository, even if you want to install builds from the edge or test repositories as well. To add the edge or test repository, add the word edge or test (or both) after the word stable in the commands below.
-# #DOCKER_REPOS="stable edge"
-# DOCKER_REPOS="stable"
-# 
-# sudo add-apt-repository \
-#    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-#    $(lsb_release -cs) \
-#    $DOCKER_REPOS"
-# 
-# # INSTALL DOCKER CE
-# 
-# # 1. Update the apt package index.
-# 
-# sudo apt-get --yes --quiet update
-# 
-# # 2. Install the latest version of Docker CE, or go to the next step to install a specific version. Any existing installation of Docker is replaced.
-# if [ "$docker_version" ]; then
-#   sudo apt-get install --yes --quiet docker-ce=$docker_version
-# else
-#   sudo apt-get install --yes --quiet docker-ce
-# fi
+set -e # Exit if any subcommand fails
+set -x # Print commands for troubleshooting
 
+if ! grep centos /etc/os-release; then
 
-sudo yum install -y yum-utils
+    # Install Docker CE on Ubuntu per
+    # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/
 
-sudo yum-config-manager \
-    --add-repo \
-    https://download.docker.com/linux/centos/docker-ce.repo
+    # From https://github.com/stefanlasiewski/vagrant-ubuntu-docker/blob/756db1689947b1ba6eb360354bc10150c510a52a/install-docker.sh
 
-sudo yum install -y docker-ce docker-ce-cli containerd.io
+    # The Docker version may be specified as $1
+    if [ $# -eq 1 ]; then
+      docker_version=$1
+    fi
 
-sudo systemctl enable docker
-sudo systemctl start docker
+    # 1. Update the apt package index:
 
+    sudo apt-get --yes --quiet update
+
+    # 2. Install packages to allow apt to use a repository over HTTPS:
+
+    sudo apt-get --yes --quiet install \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        software-properties-common
+
+    # 3. Add Docker’s official GPG key:
+
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+    # Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint.
+
+    sudo apt-key fingerprint 0EBFCD88
+
+    # 4. Use the following command to set up the stable repository. You always need the stable repository, even if you want to install builds from the edge or test repositories as well. To add the edge or test repository, add the word edge or test (or both) after the word stable in the commands below.
+    #DOCKER_REPOS="stable edge"
+    DOCKER_REPOS="stable"
+
+    sudo add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) \
+       $DOCKER_REPOS"
+
+    # INSTALL DOCKER CE
+
+    # 1. Update the apt package index.
+
+    sudo apt-get --yes --quiet update
+
+    # 2. Install the latest version of Docker CE, or go to the next step to install a specific version. Any existing installation of Docker is replaced.
+    if [ "$docker_version" ]; then
+      sudo apt-get install --yes --quiet docker-ce=$docker_version
+    else
+      sudo apt-get install --yes --quiet docker-ce
+    fi
+
+else
+
+    sudo yum install -y yum-utils
+
+    sudo yum-config-manager \
+        --add-repo \
+        https://download.docker.com/linux/centos/docker-ce.repo
+
+    sudo yum install -y docker-ce docker-ce-cli containerd.io
+
+    sudo systemctl enable docker
+    sudo systemctl start docker
+
+    # net-tools for 'route' command
+    sudo yum install -y git net-tools
+
+fi
 
 # 4. Verify that Docker CE is installed correctly by running the hello-world image.
 
 sudo docker run --rm hello-world
-
 
 
 # Add current user to group docker to not have to always do 'sudo docker'
@@ -81,9 +87,6 @@ if [ -n "`df -h | grep ^vagrant`" ]; then
     # $USER was 'root' not 'vagrant' during provisionning step
     sudo usermod -a -G docker vagrant
 fi
-
-# net-tools for 'route' command
-sudo yum install -y git net-tools
 
 # install docker-compose, from https://gist.github.com/wdullaer/f1af16bd7e970389bad3
 LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"|tail -1`"

--- a/birdhouse/vagrant-utils/provision.sh
+++ b/birdhouse/vagrant-utils/provision.sh
@@ -3,4 +3,4 @@
 cd /vagrant/birdhouse
 vagrant-utils/install-docker.sh
 vagrant-utils/configure-pavics.sh
-#vagrant-utils/configure-pagekite
+vagrant-utils/configure-pagekite

--- a/birdhouse/vagrant-utils/provision.sh
+++ b/birdhouse/vagrant-utils/provision.sh
@@ -3,4 +3,4 @@
 cd /vagrant/birdhouse
 vagrant-utils/install-docker.sh
 vagrant-utils/configure-pavics.sh
-vagrant-utils/configure-pagekite
+#vagrant-utils/configure-pagekite

--- a/vagrant_variables.yml.example
+++ b/vagrant_variables.yml.example
@@ -71,5 +71,5 @@ domain: ouranos.ca
 # memory: 8192
 # cpus: 2
 # disksize: '100GB'
-# box: 'ubuntu/bionic64'
-# box: 'centos/7'
+# box: 'ubuntu/bionic64'  # no manual steps required
+# box: 'centos/7'  # will require manual 'vagrant-utils/disk-resize' inside box

--- a/vagrant_variables.yml.example
+++ b/vagrant_variables.yml.example
@@ -63,8 +63,6 @@ domain: ouranos.ca
 # testing/debugging and to have a real SSL certificate.  Using the example
 # below, this box will be available at https://SUB-NAME.pagekite.me/
 #
-# Pagekite only works for ubuntu based box.  Centos not supported yet.
-#
 # kitename: NAME.pagekite.me
 # kitesecret: SECRET
 # kitesubdomain: SUB

--- a/vagrant_variables.yml.example
+++ b/vagrant_variables.yml.example
@@ -59,3 +59,5 @@ domain: ouranos.ca
 # memory: 8192
 # cpus: 2
 # disksize: '100GB'
+# box: 'ubuntu/bionic64'
+# box: 'centos/7'

--- a/vagrant_variables.yml.example
+++ b/vagrant_variables.yml.example
@@ -47,9 +47,23 @@ domain: ouranos.ca
 #
 # ssh_deploy_key: "~/.ssh/id_rsa_git_ssh_read_only"
 
+# LetsEncrypt settings
+#
+# Requires port 80 and 443 directly open on the internet (could be insecure).
+# If this is not possible, use Pagekite below to have a real SSL certificate
+# and to expose your VM on the internet.
+#
+# letsencrypt_email is also used as SUPPORT_EMAIL in env.local.
+#
+# If letsencrypt_email is set, will get SSL cert from LetsEncrypt.
+#
+#letsencrypt_email: helpdesk@example.com
+
 # Pagekite info to expose this vagrant box to the internet for collaborative
-# testing/debugging.  Using the example below, this box will be available at
-# SUB-NAME.pagekite.me
+# testing/debugging and to have a real SSL certificate.  Using the example
+# below, this box will be available at https://SUB-NAME.pagekite.me/
+#
+# Pagekite only works for ubuntu based box.  Centos not supported yet.
 #
 # kitename: NAME.pagekite.me
 # kitesecret: SECRET


### PR DESCRIPTION
Fixes https://github.com/bird-house/birdhouse-deploy/issues/27.

Centos7 support added to Vagrant to reproduce problems found on Medus in PR https://github.com/bird-house/birdhouse-deploy/pull/39 (commit https://github.com/bird-house/birdhouse-deploy/commit/6036dbd5ff072544d902e7b84b5eff361b00f78b):

Problem 1: wget httpS url not working in bash docker image breaking the notebook autodeploy when running under the new scheduler autodeploy: **not reproducible**

Problem 2: all containers are destroyed and recreated when alternating between manually running `./pavics-compose.sh up -d` locally and when the same command is executed automatically by the scheduler autodeploy inside its own container: **not reproducible**

Problem 3: `sysctl: error: 'net.ipv4.tcp_tw_reuse' is an unknown key` on `./pavics-compose.sh up -d` when executed automatically by the scheduler autodeploy inside its own container: **reproduced** but seems **harmless** so **not fixing** it.

Problem 4: current user lose write permission to birdhouse-deploy checkout and other checkout in `AUTODEPLOY_EXTRA_REPOS` when using scheduler autodeploy: **fixed**

Problem 5: no documentation for the new scheduler autodeploy: **fixed**

Another autodeploy fix found while working on this PR: notebook autodeploy broken when `/data/jupyterhub_user_data/tutorial-notebooks` dir do not pre-exist.  Regression from this commit https://github.com/bird-house/birdhouse-deploy/pull/16/commits/6ddaddc74d384299e45b0dc8d50a63e59b3cc0d5 (PR https://github.com/bird-house/birdhouse-deploy/pull/16): before that commit the entire dir was copied, not just the content, so the dir was created automatically.

Centos7 Vagrant box experience is not completely automated as Ubuntu box, even when using the same vagrant-disksize Vagrant plugin as Ubuntu box.  Manual disk resize instruction is provided.  Candidate for automation later if we destroy and recreate Centos7 box very often.  Hopefully the problem is not there for Centos8 so we can forget about this annoyance.

Automatic generation of SSL certificate from LetsEncrypt is also added for both Ubuntu and Centos Vagrant box.  Can be used outside of Vagrant so Medus and Boreas can also benefit next time, if needed.  Later docker image of `certbot` is used so should already be using ACMEv2 protocol (ACMEv1 is being deprecated).

Pagekite is also preserved for both boxes for when exposing port 80 and 443 directly on the internet is not possible but PAVICS still need a real SSL certificate.

Test server: https://lvupavicsmaster.ouranos.ca (Centos7, on internet with LetsEncrypt SSL cert).

Jenkins run only have known errors: http://jenkins.ouranos.ca/job/ouranos-staging/job/lvupavicsmaster.ouranos.ca/4/console

![2020-04-22-070604_1299x1131_scrot](https://user-images.githubusercontent.com/11966697/79974607-a2707b80-8467-11ea-85b6-3b03f198ce9b.png)
