### PR TITLE
Fix notebook autodeploy wipe already deployed notebook when GitHub down.

### DIFF
--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -77,7 +77,7 @@ TMP_SCRIPT="$TMPDIR/deploy-notebook"
 cat << __EOF__ > $TMP_SCRIPT
 #!/bin/sh -x
 
-if [ -n "`ls --almost-all /$TUTORIAL_NOTEBOOKS_DIR/`" ]; then
+if [ -n "\`ls -A /$TUTORIAL_NOTEBOOKS_DIR/\`" ]; then
     cd $NOTEBOOK_DIR_MNT
     rm -rf $TUTORIAL_NOTEBOOKS_DIR/*
     cp -rv /$TUTORIAL_NOTEBOOKS_DIR/* $TUTORIAL_NOTEBOOKS_DIR

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Deploy tutorial notebooks to JupyterHub instance under folder
 # tutorial-notebooks.
 #

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -76,11 +76,13 @@ TMP_SCRIPT="$TMPDIR/deploy-notebook"
 cat << __EOF__ > $TMP_SCRIPT
 #!/bin/sh -x
 
-cd $NOTEBOOK_DIR_MNT
-rm -rf $TUTORIAL_NOTEBOOKS_DIR/*
-cp -rv /$TUTORIAL_NOTEBOOKS_DIR/* $TUTORIAL_NOTEBOOKS_DIR
-# make read-only
-chown -R root:root $TUTORIAL_NOTEBOOKS_DIR
+if [ -n "`ls --almost-all /$TUTORIAL_NOTEBOOKS_DIR/`" ]; then
+    cd $NOTEBOOK_DIR_MNT
+    rm -rf $TUTORIAL_NOTEBOOKS_DIR/*
+    cp -rv /$TUTORIAL_NOTEBOOKS_DIR/* $TUTORIAL_NOTEBOOKS_DIR
+    # make read-only
+    chown -R root:root $TUTORIAL_NOTEBOOKS_DIR
+fi
 __EOF__
 chmod a+x $TMP_SCRIPT
 

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -25,7 +25,8 @@ LOG_FILE="/var/log/PAVICS/notebookdeploy.log"
 exec >>$LOG_FILE 2>&1
 
 cleanup_on_exit() {
-    rm -rfv "$TMPDIR"
+    rm -rf "$TMPDIR"
+    set +x
     echo "
 notebookdeploy finished START_TIME=$START_TIME
 notebookdeploy finished   END_TIME=`date -Isecond`"
@@ -69,8 +70,8 @@ wget --quiet --output-document - https://github.com/Ouranosinc/PAVICS-e2e-workfl
 ./downloadrepos
 ./reorg-notebooks
 mv -v PAVICS-e2e-workflow-tests-master/notebooks/*.ipynb ./
-rm -rfv PAVICS-e2e-workflow-tests-master
-rm -rfv downloadrepos default_build_params reorg-notebooks
+rm -rf PAVICS-e2e-workflow-tests-master
+rm -rf downloadrepos default_build_params reorg-notebooks
 
 TMP_SCRIPT="$TMPDIR/deploy-notebook"
 cat << __EOF__ > $TMP_SCRIPT
@@ -95,8 +96,6 @@ docker run --rm \
   -v "$JUPYTERHUB_USER_DATA_DIR":$NOTEBOOK_DIR_MNT:rw \
   --entrypoint /deploy-notebook \
   bash
-
-set +x
 
 
 # vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Fixes https://github.com/bird-house/birdhouse-deploy/issues/43

Fail early with any unexpected error to not wipe already deployed notebooks.

Check source dir not empty before wiping dest dir containing already deployed notebooks.

Reduce cleaning verbosity for more concise logging.

To fix this error found in production logs when Github is down today:
```
notebookdeploy START_TIME=2020-04-23T10:01:01-0400
++ mktemp -d -t notebookdeploy.XXXXXXXXXXXX
+ TMPDIR=/tmp/notebookdeploy.ICk70Vto2LaE
+ cd /tmp/notebookdeploy.ICk70Vto2LaE
+ mkdir tutorial-notebooks
+ cd tutorial-notebooks
+ wget --quiet https://raw.githubusercontent.com/Ouranosinc/PAVICS-e2e-workflow-tests/master/downloadrepos
+ chmod a+x downloadrepos
chmod: cannot access ‘downloadrepos’: No such file or directory
+ wget --quiet https://raw.githubusercontent.com/Ouranosinc/PAVICS-e2e-workflow-tests/master/default_build_params
+ wget --quiet https://raw.githubusercontent.com/Ouranosinc/PAVICS-e2e-workflow-tests/master/binder/reorg-notebooks
+ chmod a+x reorg-notebooks
chmod: cannot access ‘reorg-notebooks’: No such file or directory
+ wget --quiet --output-document - https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/archive/master.tar.gz
+ tar xz

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
+ ./downloadrepos
/etc/cron.hourly/PAVICS-deploy-notebooks: line 63: ./downloadrepos: No such file or directory
+ ./reorg-notebooks
/etc/cron.hourly/PAVICS-deploy-notebooks: line 64: ./reorg-notebooks: No such file or directory
+ mv -v 'PAVICS-e2e-workflow-tests-master/notebooks/*.ipynb' ./
mv: cannot stat ‘PAVICS-e2e-workflow-tests-master/notebooks/*.ipynb’: No such file or directory
+ rm -rfv PAVICS-e2e-workflow-tests-master
+ rm -rfv downloadrepos default_build_params reorg-notebooks
+ TMP_SCRIPT=/tmp/notebookdeploy.ICk70Vto2LaE/deploy-notebook
+ cat
+ chmod a+x /tmp/notebookdeploy.ICk70Vto2LaE/deploy-notebook
+ docker pull bash
Using default tag: latest
latest: Pulling from library/bash
Digest: sha256:febb3d74f41f2405fe21b7c7b47ca1aee0eda0a3ffb5483ebe3423639d30d631
Status: Image is up to date for bash:latest
+ docker run --rm --name deploy_tutorial_notebooks -u root -v /tmp/notebookdeploy.ICk70Vto2LaE/deploy-notebook:/deploy-notebook:ro -v /tmp/notebookdeploy.ICk70Vto2LaE/tutorial-notebooks:/tutorial-notebooks:ro -v /data/jupyterhub_user_data:/notebook_dir:rw --entrypoint /deploy-notebook bash
+ cd /notebook_dir
+ rm -rf tutorial-notebooks/WCS_example.ipynb tutorial-notebooks/WFS_example.ipynb tutorial-notebooks/WMS_example.ipynb tutorial-notebooks/WPS_example.ipynb tutorial-notebooks/catalog_search.ipynb tutorial-notebooks/dap_subset.ipynb tutorial-notebooks/esgf-compute-api-examples-devel tutorial-notebooks/esgf-dap.ipynb tutorial-notebooks/finch-usage.ipynb tutorial-notebooks/hummingbird.ipynb tutorial-notebooks/opendap.ipynb tutorial-notebooks/pavics_thredds.ipynb tutorial-notebooks/raven-master tutorial-notebooks/rendering.ipynb tutorial-notebooks/subsetting.ipynb
+ cp -rv '/tutorial-notebooks/*' tutorial-notebooks
cp: can't stat '/tutorial-notebooks/*': No such file or directory
+ chown -R root:root tutorial-notebooks
+ set +x
removed directory: ‘/tmp/notebookdeploy.ICk70Vto2LaE/tutorial-notebooks’
removed ‘/tmp/notebookdeploy.ICk70Vto2LaE/deploy-notebook’
removed directory: ‘/tmp/notebookdeploy.ICk70Vto2LaE’

notebookdeploy finished START_TIME=2020-04-23T10:01:01-0400
notebookdeploy finished   END_TIME=2020-04-23T10:02:12-0400
```