### PR TITLE
add script to detect user install in jupyter env

### DIFF
--- a/birdhouse/scripts/detect-user-install-in-jupyter-env
+++ b/birdhouse/scripts/detect-user-install-in-jupyter-env
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Detect user install (pip intall --user) in Jupyter environment.
+#
+# User install is error-prone since it overrides the official package version
+# from the environment.  This means when new environments are available, user
+# will not receive update for the packages that are user installed since the
+# version is pinned at the user installed version.
+#
+
+THIS_FILE="`realpath "$0"`"
+THIS_DIR="`dirname "$THIS_FILE"`"
+
+# Default values
+. $THIS_DIR/../common.env
+
+if [ -e "$THIS_DIR/../env.local" ]; then
+    # Override default values
+    . $THIS_DIR/../env.local
+fi
+
+set -x
+
+START_TIME="`date -Isecond`"
+
+cd $JUPYTERHUB_USER_DATA_DIR
+
+# Fresh new user do not have .local/lib and .local/bin yet so these commands
+# will return error and it is normal.
+ls -a */.home/.local/lib/python*/site-packages
+ls -a */.home/.local/bin
+
+set +x
+
+echo "
+Errors like
+  ls: cannot access */.home/.local/lib/python*/site-packages: No such file or directory
+  ls: cannot access */.home/.local/bin: No such file or directory
+means no users have user install in their Jupyter env.
+
+If there are user installs, remove by renaming the site-packages and bin folder
+instead of deleting so can rollback if necessary.
+
+Users can uninstall all their user installs themselves from a notebook with:
+  !pip freeze --user  # list their user installs
+  !(pip freeze --user | xargs pip uninstall -y)  # remove all user installs
+  !pip freeze --user  # confirm all gone
+"


### PR DESCRIPTION
Danger of user install explained in script header.

What to do if found is explained in reminder message at end.

@huard  @richardarsenault you both have user install in your respective Jupyter env since the last time we had to hack your env for the Raven demo.

Let me know if you want to wipe all those user install yourself (see message at end of script for how to) or I do it for you.

We just had a new Jupyter env (https://github.com/bird-house/birdhouse-deploy/pull/45 https://github.com/bird-house/birdhouse-deploy/commit/2a5dc1ff2465f5da7a0e248d211be8836e1216fe) so to test this new env properly, you should not have any user installs.

```
arsenault/.home/.local/lib/python3.7/site-packages:
.   birdhouse_birdy-0.6.8.dist-info  geopandas                  imageio                  networkx                pandas                   PyWavelets-1.1.1.dist-info  scikit_image-0.16.2.dist-info  tests
..  birdy                            geopandas-0.6.2.dist-info  imageio-2.8.0.dist-info  networkx-2.4.dist-info  pandas-0.25.3.dist-info  pywt                        skimage

dhuard/.home/.local/lib/python3.7/site-packages:
.  ..  birdhouse_birdy-0.6.8.dist-info  google  protobuf-3.11.3.dist-info  protobuf-3.11.3-py3.7-nspkg.pth  requests_oauthlib  requests_oauthlib-1.3.0.dist-info  siphon  siphon-0.8.0.dist-info  tests

arsenault/.home/.local/bin:
.  ..  birdy  imageio_download_bin  imageio_remove_bin  skivi

dhuard/.home/.local/bin:
.  ..  birdy
```