### PR TITLE
jupyter: update to pavics/workflow-tests:200507

### DIFF
--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -1,7 +1,7 @@
 # All env this common.env can be overridden by env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200427"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200507"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.2"
 export GENERIC_BIRD_IMAGE="$FINCH_IMAGE"


### PR DESCRIPTION
Raven PR https://github.com/Ouranosinc/raven/pull/266 (commit
https://github.com/Ouranosinc/raven/commit/0763bf52abec1bc0a70927de3a2dc2cc1cf77ec3)
removed salem dependency and replaced with rioxarray.

Also add packages for the
[`custom_climate_portraits`](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/tree/custom_climate_portraits)
branch  (PR
https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/35).

Noticeable changes:
```diff
  # conda release of bokeh seems to trail behind pypi
>   - bokeh=2.0.1=py37hc8dfbb8_0
<     - bokeh==2.0.2
>   - jupyter_bokeh=2.0.1=py_0

  # should already exist, not sure why conda env export report this as new
>   - dask=2.15.0=py_0

  # unpinned since salem is removed
<   - pandas=0.25.3=py37hb3f55d8_0
>   - pandas=1.0.3=py37h0da4684_1

<     - salem==0.2.4
>   - rioxarray=0.0.26=py_0

  # packages for custom_climate_portraits branch
>   - geoviews=1.8.1=py_0
>   - h5netcdf=0.8.0=py_0
>   - holoviews=1.13.2=pyh9f0ad1d_0
>   - panel=0.9.5=py_1
>   - hvplot=0.5.2=py_0
>   - pscript=0.7.3=py_0
>   - siphon=0.8.0=py37_1002
>     - ipython-blocking==0.2.1
```

See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/44
(commit
https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/bb81982e3fd92bff437eddc5d4ae28202b3ef07c)
for more info.