### PR TITLE
jupyter: new image for additional plugins

### DIFF
--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -1,7 +1,7 @@
 # All env this common.env can be overridden by env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200603"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200605"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.2"
 export GENERIC_BIRD_IMAGE="$FINCH_IMAGE"


### PR DESCRIPTION
Matching PR to deploy the new Jupyter image to PAVICS.

Added:

* https://github.com/hadim/jupyter-archive
  Download entire folder as archive.

* https://blog.jupyter.org/a-visual-debugger-for-jupyter-914e61716559

* https://github.com/plotly/jupyter-dash
  Develop Plotly Dash apps interactively from within Jupyter environments.

Noticeable changes:
```diff
>   - jupyter-archive=0.6.2=py_0
>   - jupyter-dash=0.2.1.post1=py_0

<   - owslib=0.19.2=py_1
>   - owslib=0.20.0=py_0

>   - xeus-python=0.7.1=py37h99015e2_1
```

See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/46 (commit
https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/441edde3b381eff7ce82e5a171323b31196553be)
for more info.