### PR TITLE
flyingpigeon: update to version 1.6

### DIFF
--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -136,7 +136,7 @@ services:
     restart: always
 
   flyingpigeon:
-    image: birdhouse/flyingpigeon:1.5.1
+    image: birdhouse/flyingpigeon:1.6
     container_name: flyingpigeon
     environment:
       - PYWPS_CFG=/wps.cfg


### PR DESCRIPTION
Deploy the new Flyingpigeon 1.6 on PAVICS.

Has been deployed to Medus test environment.

flyingpigeon changelog from release commit
https://github.com/bird-house/flyingpigeon/commit/a6f54ed0c20919485c2420295729e30f914cfa15
(PR https://github.com/bird-house/flyingpigeon/pull/332)

1.6 (2020-06-10)
================
* remove eggshell dependency
* notebooks are part of the test suite
* improved plot processes
* remove mosaic option for subset processes
* polygon subset processes files separately instead of an entire data-set at once
* multiple outputs listed in Metalink output
* update pywps to 4.2.3
* use cruft to keep up-to-date with the cookie-cutter template