### PR TITLE
flyingpigeon: set maxsingleinputsize = 2097152000.0

### DIFF
--- a/birdhouse/config/flyingpigeon/wps.cfg.template
+++ b/birdhouse/config/flyingpigeon/wps.cfg.template
@@ -1,6 +1,7 @@
 [server]
 outputurl = https://${PAVICS_FQDN_PUBLIC}/wpsoutputs
 outputpath = /data/wpsoutputs
+maxsingleinputsize = 2097152000.0
 
 [logging]
 level = INFO


### PR DESCRIPTION
Requested by @nilshempelmann for a soilmoisture data set.

This is a 2G file limit !  I wonder if it is possible to give a URL path and the WPS service will fetch the file itself so we do not have to set such a big file limit.