### PR TITLE
jupyter: new build and add nc-time-axis

### DIFF
--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -1,7 +1,7 @@
 # All env this common.env can be overridden by env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200605"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200716"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.2"
 export GENERIC_BIRD_IMAGE="$FINCH_IMAGE"


### PR DESCRIPTION
Corresponding change to deploy the new Jupyter env to PAVICS.

Noticeable changes:
```diff
<   - dask=2.17.2=py_0
>   - dask=2.20.0=py_0

>   - nc-time-axis=1.2.0=py_1

<   - xarray=0.15.1=py_0
>   - xarray=0.16.0=py_0

<     - xclim==0.17.0
>     - xclim==0.18.0
```

See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/47
(commit
https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/4e03a674930f0974e13724940eee7a608c2158c0)
for more info.