### PR TITLE
proxy: increase timeout for reading a response from the proxied server

### DIFF
--- a/birdhouse/config/proxy/nginx.conf
+++ b/birdhouse/config/proxy/nginx.conf
@@ -30,6 +30,9 @@ http {
     client_max_body_size 1000m;
     client_body_timeout 600s;
 
+    # timeout for reading a response from the proxied server
+    proxy_read_timeout 120s;  # default 60s
+
     include /etc/nginx/conf.d/*.conf;
 
     # for other extra components to extend Nginx


### PR DESCRIPTION
Fixes https://github.com/Ouranosinc/raven/issues/286

"there seems to be a problem with the size of the ncml and the timeout
if I use more than 10-12 years as the historical data. I get a :
"Netcdf: DAP failure" error if I use too many years."

```
________________________________________________________ TestBiasCorrect.test_bias_correction ________________________________________________________
Traceback (most recent call last):
  File "/zstore/repos/raven/tests/test_bias_correction.py", line 20, in test_bias_correction
    ds = (xr.open_dataset(hist_data).sel(lat=slice(lat + 1, lat - 1),lon=slice(lon - 1, lon + 1), time=slice(dt.datetime(1991,1,1), dt.datetime(2010,12,31))).mean(dim={"lat", "lon"}, keep_attrs=True))
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/common.py", line 84, in wrapped_func
    func, dim, skipna=skipna, numeric_only=numeric_only, **kwargs
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/dataset.py", line 4313, in reduce
    **kwargs,
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/variable.py", line 1586, in reduce
    input_data = self.data if allow_lazy else self.values
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/variable.py", line 349, in data
    return self.values
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/variable.py", line 457, in values
    return _as_array_or_item(self._data)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/variable.py", line 260, in _as_array_or_item
    data = np.asarray(data)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/numpy/core/_asarray.py", line 83, in asarray
    return array(a, dtype, copy=False, order=order)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/indexing.py", line 677, in __array__
    self._ensure_cached()
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/indexing.py", line 674, in _ensure_cached
    self.array = NumpyIndexingAdapter(np.asarray(self.array))
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/numpy/core/_asarray.py", line 83, in asarray
    return array(a, dtype, copy=False, order=order)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/indexing.py", line 653, in __array__
    return np.asarray(self.array, dtype=dtype)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/numpy/core/_asarray.py", line 83, in asarray
    return array(a, dtype, copy=False, order=order)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/indexing.py", line 557, in __array__
    return np.asarray(array[self.key], dtype=None)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/backends/netCDF4_.py", line 73, in __getitem__
    key, self.shape, indexing.IndexingSupport.OUTER, self._getitem
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/core/indexing.py", line 837, in explicit_indexing_adapter
    result = raw_indexing_method(raw_key.tuple)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/backends/netCDF4_.py", line 85, in _getitem
    array = getitem(original_array, key)
  File "/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/xarray/backends/common.py", line 54, in robust_getitem
    return array[key]
  File "netCDF4/_netCDF4.pyx", line 4408, in netCDF4._netCDF4.Variable.__getitem__
  File "netCDF4/_netCDF4.pyx", line 5352, in netCDF4._netCDF4.Variable._get
  File "netCDF4/_netCDF4.pyx", line 1887, in netCDF4._netCDF4._ensure_nc_success
RuntimeError: NetCDF: DAP failure
```