### PR TITLE
jupyter: new update image with hvplot pinned to older version for violin plot

### DIFF
--- a/birdhouse/common.env
+++ b/birdhouse/common.env
@@ -1,7 +1,7 @@
 # All env this common.env can be overridden by env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200716"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200803"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.2"
 export GENERIC_BIRD_IMAGE="$FINCH_IMAGE"


### PR DESCRIPTION
See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/48 for more detailed info.

Deployed to Medus for testing (as regular PAVICS image, not the devel image).  @aulemahal let me know if violin plot is finally working.

Noticeable changes:
```diff
<   - hvplot=0.6.0=pyh9f0ad1d_0
>   - hvplot=0.5.2=py_0

<   - dask=2.20.0=py_0
>   - dask=2.22.0=py_0

<   - geopandas=0.8.0=py_1
>   - geopandas=0.8.1=py_0

<   - pandas=1.0.5=py37h0da4684_0
>   - pandas=1.1.0=py37h3340039_0

<   - matplotlib=3.2.2=1
>   - matplotlib=3.3.0=1

<   - numpy=1.18.5=py37h8960a57_0
>   - numpy=1.19.1=py37h8960a57_0

<   - cryptography=2.9.2=py37hb09aad4_0
>   - cryptography=3.0=py37hb09aad4_0

<   - python=3.7.6=h8356626_5_cpython
>   - python=3.7.8=h6f2ec95_1_cpython

<   - nbval=0.9.5=py_0
>   - nbval=0.9.6=pyh9f0ad1d_0

<   - pytest=5.4.3=py37hc8dfbb8_0
>   - pytest=6.0.1=py37hc8dfbb8_0
```