### PR TITLE
Auto-renew LetsEncrypt SSL certificate

### DIFF
--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -1,5 +1,6 @@
 ##############################################################################
 # Configuration vars, set in env.local before sourcing this file.
+# This job assume the "scheduler" component is enabled.
 ##############################################################################
 
 if [ -z "$RENEW_LETSENCRYPT_SSL_SCHEDULE" ]; then

--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -1,0 +1,25 @@
+if [ -z "`echo "$AUTODEPLOY_EXTRA_SCHEDULER_JOBS" | grep renew_letsencrypt_ssl`" ]; then
+
+    # Add job only if not already added (config is read twice during
+    # autodeploy process.
+
+    export AUTODEPLOY_EXTRA_SCHEDULER_JOBS="
+$AUTODEPLOY_EXTRA_SCHEDULER_JOBS
+
+- name: renew_letsencrypt_ssl
+  comment: Auto-renew LetsEncrypt SSL certificate
+  schedule: '22 5 * * *'
+  command: '${PWD}/deployment/certbotwrapper'
+  dockerargs: >-
+    --rm --name renew_letsencrypt_ssl
+    --volume /var/run/docker.sock:/var/run/docker.sock:ro
+    --volume ${PWD}/..:${PWD}/..:ro
+    --volume /var/log/PAVICS:/var/log/PAVICS:rw
+    --volume ${SSL_CERTIFICATE}:${SSL_CERTIFICATE}:rw
+    --env FORCE_CERTBOT_E2E=1
+    --env CERTBOT_RENEW=1
+    --env CERTBOTWRAPPER_LOGFILE=/var/log/PAVICS/renew_letsencrypt_ssl.log
+  image: 'pavics/docker-compose-git:docker-18.09.7-compose-1.25.1'
+"
+
+fi

--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -3,8 +3,18 @@
 # This job assume the "scheduler" component is enabled.
 ##############################################################################
 
+# Cronjob schedule to trigger renew attempt.
 if [ -z "$RENEW_LETSENCRYPT_SSL_SCHEDULE" ]; then
     RENEW_LETSENCRYPT_SSL_SCHEDULE="22 5 * * *"  # UTC
+fi
+
+# Number of parents above this repo to volume-mount.
+# This is needed for when env.local is a relative symlink.
+# Default is just 1 level, so "/..".
+# If no level needed, set to "/".
+# If 2 levels: "/../.." and so on.
+if [ -z "$RENEW_LETSENCRYPT_SSL_NUM_PARENTS_MOUNT" ]; then
+    RENEW_LETSENCRYPT_SSL_NUM_PARENTS_MOUNT="/.."
 fi
 
 # Set RENEW_LETSENCRYPT_SSL_EXTRA_OPTS to pass more options to certbotwrapper.
@@ -27,6 +37,9 @@ fi
 #   │   ├── docker-compose-extra.yml
 #   │   ├── env.local.real
 #   │   ├── .git/
+#
+#   If the relative symlink need higher up level than just sibling level, set
+#   RENEW_LETSENCRYPT_SSL_NUM_PARENTS_MOUNT accordingly.
 
 ##############################################################################
 # End configuration vars
@@ -48,7 +61,7 @@ $AUTODEPLOY_EXTRA_SCHEDULER_JOBS
   dockerargs: >-
     --rm --name renew_letsencrypt_ssl
     --volume /var/run/docker.sock:/var/run/docker.sock:ro
-    --volume ${COMPOSE_DIR}/../..:${COMPOSE_DIR}/../..:ro
+    --volume ${COMPOSE_DIR}/..${RENEW_LETSENCRYPT_SSL_NUM_PARENTS_MOUNT}:${COMPOSE_DIR}/..${RENEW_LETSENCRYPT_SSL_NUM_PARENTS_MOUNT}:ro
     --volume /var/log/PAVICS:/var/log/PAVICS:rw
     --volume `dirname ${SSL_CERTIFICATE}`:`dirname ${SSL_CERTIFICATE}`:rw
     --env COMPOSE_DIR=${COMPOSE_DIR}

--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -50,7 +50,7 @@ $AUTODEPLOY_EXTRA_SCHEDULER_JOBS
     --volume /var/run/docker.sock:/var/run/docker.sock:ro
     --volume ${COMPOSE_DIR}/../..:${COMPOSE_DIR}/../..:ro
     --volume /var/log/PAVICS:/var/log/PAVICS:rw
-    --volume ${SSL_CERTIFICATE}:${SSL_CERTIFICATE}:rw
+    --volume `dirname ${SSL_CERTIFICATE}`:`dirname ${SSL_CERTIFICATE}`:rw
     --env COMPOSE_DIR=${COMPOSE_DIR}
     --env FORCE_CERTBOT_E2E=1
     --env CERTBOT_RENEW=1

--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -1,3 +1,23 @@
+##############################################################################
+# Configuration vars, set in env.local before sourcing this file.
+##############################################################################
+
+if [ -z "$RENEW_LETSENCRYPT_SSL_SCHEDULE" ]; then
+    RENEW_LETSENCRYPT_SSL_SCHEDULE="22 5 * * *"  # UTC
+fi
+
+# Set RENEW_LETSENCRYPT_SSL_EXTRA_OPTS to pass more options to certbotwrapper.
+# See certbotwrapper header comment for some possible useful options.
+
+# Make sure SSL_CERTIFICATE is an absolute path for volume-mount to work
+# properly.  SSL_CERTIFICATE should also not be under this repo since this repo
+# is volume-mount read-only.
+
+##############################################################################
+# End configuration vars
+##############################################################################
+
+
 if [ -z "`echo "$AUTODEPLOY_EXTRA_SCHEDULER_JOBS" | grep renew_letsencrypt_ssl`" ]; then
 
     # Add job only if not already added (config is read twice during
@@ -8,8 +28,8 @@ $AUTODEPLOY_EXTRA_SCHEDULER_JOBS
 
 - name: renew_letsencrypt_ssl
   comment: Auto-renew LetsEncrypt SSL certificate
-  schedule: '22 5 * * *'
-  command: '${PWD}/deployment/certbotwrapper'
+  schedule: '$RENEW_LETSENCRYPT_SSL_SCHEDULE'
+  command: '${PWD}/deployment/certbotwrapper $RENEW_LETSENCRYPT_SSL_EXTRA_OPTS'
   dockerargs: >-
     --rm --name renew_letsencrypt_ssl
     --volume /var/run/docker.sock:/var/run/docker.sock:ro

--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -9,9 +9,23 @@ fi
 # Set RENEW_LETSENCRYPT_SSL_EXTRA_OPTS to pass more options to certbotwrapper.
 # See certbotwrapper header comment for some possible useful options.
 
-# Make sure SSL_CERTIFICATE is an absolute path for volume-mount to work
-# properly.  SSL_CERTIFICATE should also not be under this repo since this repo
-# is volume-mount read-only.
+# NOTE:
+#
+# * Make sure SSL_CERTIFICATE is an absolute path for volume-mount to work
+#   properly.  SSL_CERTIFICATE should also *not* be under this repo since this
+#   repo is volume-mount read-only.
+#
+# * If env.local is a relative symlink (absolute symlink unsupported at the
+#   moment) to a real file elsewhere, the real file is assumed to be sibling
+#   or descendant of sibling of this repo checkout.  Ex:
+#
+#   ├── birdhouse-deploy/  # this repo
+#   │   ├── birdhouse/
+#   │   │   ├── env.local  # relative symlink to env.local.real below
+#   ├── private-config/    # sibling level of this repo
+#   │   ├── docker-compose-extra.yml
+#   │   ├── env.local.real
+#   │   ├── .git/
 
 ##############################################################################
 # End configuration vars
@@ -33,7 +47,7 @@ $AUTODEPLOY_EXTRA_SCHEDULER_JOBS
   dockerargs: >-
     --rm --name renew_letsencrypt_ssl
     --volume /var/run/docker.sock:/var/run/docker.sock:ro
-    --volume ${COMPOSE_DIR}/..:${COMPOSE_DIR}/..:ro
+    --volume ${COMPOSE_DIR}/../..:${COMPOSE_DIR}/../..:ro
     --volume /var/log/PAVICS:/var/log/PAVICS:rw
     --volume ${SSL_CERTIFICATE}:${SSL_CERTIFICATE}:rw
     --env COMPOSE_DIR=${COMPOSE_DIR}

--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -29,13 +29,14 @@ $AUTODEPLOY_EXTRA_SCHEDULER_JOBS
 - name: renew_letsencrypt_ssl
   comment: Auto-renew LetsEncrypt SSL certificate
   schedule: '$RENEW_LETSENCRYPT_SSL_SCHEDULE'
-  command: '${PWD}/deployment/certbotwrapper $RENEW_LETSENCRYPT_SSL_EXTRA_OPTS'
+  command: '${COMPOSE_DIR}/deployment/certbotwrapper $RENEW_LETSENCRYPT_SSL_EXTRA_OPTS'
   dockerargs: >-
     --rm --name renew_letsencrypt_ssl
     --volume /var/run/docker.sock:/var/run/docker.sock:ro
-    --volume ${PWD}/..:${PWD}/..:ro
+    --volume ${COMPOSE_DIR}/..:${COMPOSE_DIR}/..:ro
     --volume /var/log/PAVICS:/var/log/PAVICS:rw
     --volume ${SSL_CERTIFICATE}:${SSL_CERTIFICATE}:rw
+    --env COMPOSE_DIR=${COMPOSE_DIR}
     --env FORCE_CERTBOT_E2E=1
     --env CERTBOT_RENEW=1
     --env CERTBOTWRAPPER_LOGFILE=/var/log/PAVICS/renew_letsencrypt_ssl.log

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -79,7 +79,7 @@ if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
     CERTPATH="/etc/letsencrypt/live/$CERT_DOMAIN"
     cd $THIS_DIR/..
     docker run --rm --name copy_cert \
-        -v "$CERTPATH:$CERTPATH" \
+        -v "/etc/letsencrypt:/etc/letsencrypt" \
         bash \
         cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $SSL_CERTIFICATE
     if [ -z "$FORCE_CERTBOT_RENEW_NO_START_PROXY" ]; then

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -12,14 +12,14 @@
 # * --dry-run
 #
 # Port 80 and 443 must be free at the time of invoking this script
-# (pavics-compose.sh stop proxy)
+# (docker stop proxy)
 #
 # Setting environment variable FORCE_CERTBOT_E2E=1 when calling this script
 # will perform all needed pre and post actions:
-# * pavics-compose.sh stop proxy
+# * docker stop proxy
 # * perform the certbot action
 # * concat the fullchain.pem and privkey.pem to the proper location
-# * pavics-compose.sh start proxy
+# * docker start proxy
 #
 # Setting environment variable CERTBOT_RENEW=1 when calling this script
 # will perform renew instead of requesting a new cert.  Renew mode will avoid
@@ -55,7 +55,7 @@ fi
 
 if [ ! -z "$FORCE_CERTBOT_E2E" ]; then
     cd $THIS_DIR/..
-    ./pavics-compose.sh stop proxy
+    docker stop proxy
     cd $SAVED_PWD
 fi
 CERTBOT_OPTS=""
@@ -96,7 +96,7 @@ if [ ! -z "$FORCE_CERTBOT_E2E" ]; then
     fi
     rm -v $TMP_SSL_CERT
     if [ -z "$FORCE_CERTBOT_E2E_NO_START_PROXY" ]; then
-        ./pavics-compose.sh start proxy
+        docker start proxy
     fi
     cd $SAVED_PWD
 else
@@ -108,7 +108,7 @@ CERTPATH=\"/etc/letsencrypt/live/$CERT_DOMAIN\"
 cd $THIS_DIR/..
 sudo cat \$CERTPATH/fullchain.pem \$CERTPATH/privkey.pem > $SSL_CERTIFICATE
 openssl x509 -noout -text -in $SSL_CERTIFICATE
-./pavics-compose.sh up -d
+docker start proxy
 "
 fi
 

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -13,9 +13,17 @@
 #
 # Port 80 and 443 must be free at the time of invoking this script
 # (pavics-compose.sh stop proxy)
+#
+# Setting environment variable FORCE_CERTBOT_RENEW=1 when calling this script
+# will perform all needed pre and post actions for renewal:
+# * pavics-compose.sh stop proxy
+# * perform the renewal
+# * concat the fullchain.pem and privkey.pem to the proper location
+# * pavics-compose.sh start proxy
 
 THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
+SAVED_PWD="`pwd`"
 
 # Default values
 . $THIS_DIR/../default.env
@@ -30,6 +38,12 @@ set -x
 CERT_DOMAIN="$PAVICS_FQDN_PUBLIC"
 if [ -z "$CERT_DOMAIN" ]; then
     CERT_DOMAIN="$PAVICS_FQDN"
+fi
+
+if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
+    cd $THIS_DIR/..
+    ./pavics-compose.sh stop proxy
+    cd $SAVED_PWD
 fi
 
 docker run --rm --name certbot \
@@ -58,5 +72,18 @@ sudo cat \$CERTPATH/fullchain.pem \$CERTPATH/privkey.pem > $SSL_CERTIFICATE
 openssl x509 -noout -text -in $SSL_CERTIFICATE
 ./pavics-compose.sh up -d
 "
+
+if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
+    CERTPATH="/etc/letsencrypt/live/$CERT_DOMAIN"
+    cd $THIS_DIR/..
+    docker run --rm --name copy_cert \
+        -v "$CERTPATH:$CERTPATH" \
+        bash \
+        cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $SSL_CERTIFICATE
+    if [ -z "$FORCE_CERTBOT_RENEW_NO_START_PROXY" ]; then
+        ./pavics-compose.sh start proxy
+    fi
+    cd $SAVED_PWD
+fi
 
 exit $RC

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -40,7 +40,9 @@ if [ -z "$CERT_DOMAIN" ]; then
     CERT_DOMAIN="$PAVICS_FQDN"
 fi
 
+EXTRA_CERTBOT_OPTS=""
 if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
+    EXTRA_CERTBOT_OPTS="--cert-name $CERT_DOMAIN"
     cd $THIS_DIR/..
     ./pavics-compose.sh stop proxy
     cd $SAVED_PWD
@@ -58,7 +60,7 @@ docker run --rm --name certbot \
   --no-eff-email \
   --standalone \
   --email $SUPPORT_EMAIL \
-  --domain $CERT_DOMAIN \
+  --domain $CERT_DOMAIN $EXTRA_CERTBOT_OPTS \
   "$@"
 RC=$?
 

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -38,6 +38,8 @@ START_TIME="`date -Isecond`"
 echo "==========
 certbotwrapper START_TIME=$START_TIME"
 
+set -x
+
 THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
 SAVED_PWD="`pwd`"
@@ -45,12 +47,18 @@ SAVED_PWD="`pwd`"
 # Default values
 . $THIS_DIR/../default.env
 
-if [ -e "$THIS_DIR/../env.local" ]; then
+ENV_LOCAL_FILE="$THIS_DIR/../env.local"
+
+set +x  # hide password in env.local
+
+if [ -e "$ENV_LOCAL_FILE" ]; then
     # Override default values
-    . $THIS_DIR/../env.local
+    . "$ENV_LOCAL_FILE"
+else
+    echo "WARNING: '$ENV_LOCAL_FILE' not found."
 fi
 
-set -x
+set -x  # resume logging/tracing
 
 CERT_DOMAIN="$PAVICS_FQDN_PUBLIC"
 if [ -z "$CERT_DOMAIN" ]; then

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -65,12 +65,18 @@ docker run --rm --name certbot \
 RC=$?
 
 if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
+    TMP_SSL_CERT="/tmp/tmp_certbotwrapper_ssl_cert.pem"
     CERTPATH="/etc/letsencrypt/live/$CERT_DOMAIN"
     cd $THIS_DIR/..
     docker run --rm --name copy_cert \
         -v "/etc/letsencrypt:/etc/letsencrypt" \
         bash \
-        cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $SSL_CERTIFICATE
+        cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $TMP_SSL_CERT
+    if ! diff $SSL_CERTIFICATE $TMP_SSL_CERT && [ $RC -eq 0 ]; then
+        # Only modify SSL_CERTIFICATE if there are real changes.
+        cp -v $TMP_SSL_CERT $SSL_CERTIFICATE
+    fi
+    rm -v $TMP_SSL_CERT
     if [ -z "$FORCE_CERTBOT_RENEW_NO_START_PROXY" ]; then
         ./pavics-compose.sh start proxy
     fi

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 # Renew LetsEncrypt SSL certificate using certbot docker image.
 #
 # Important:

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -34,6 +34,10 @@ if [ ! -z "$CERTBOTWRAPPER_LOGFILE" ]; then
     exec >>$CERTBOTWRAPPER_LOGFILE 2>&1
 fi
 
+START_TIME="`date -Isecond`"
+echo "==========
+certbotwrapper START_TIME=$START_TIME"
+
 THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
 SAVED_PWD="`pwd`"
@@ -111,5 +115,10 @@ openssl x509 -noout -text -in $SSL_CERTIFICATE
 docker start proxy
 "
 fi
+
+set +x
+echo "
+certbotwrapper finished START_TIME=$START_TIME
+certbotwrapper finished   END_TIME=`date -Isecond`"
 
 exit $RC

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -14,12 +14,17 @@
 # Port 80 and 443 must be free at the time of invoking this script
 # (pavics-compose.sh stop proxy)
 #
-# Setting environment variable FORCE_CERTBOT_RENEW=1 when calling this script
-# will perform all needed pre and post actions for renewal:
+# Setting environment variable FORCE_CERTBOT_E2E=1 when calling this script
+# will perform all needed pre and post actions:
 # * pavics-compose.sh stop proxy
-# * perform the renewal
+# * perform the certbot action
 # * concat the fullchain.pem and privkey.pem to the proper location
 # * pavics-compose.sh start proxy
+#
+# Setting environment variable CERTBOT_RENEW=1 when calling this script
+# will perform renew instead of requesting a new cert.  Renew mode will avoid
+# hitting the LetsEncrypt server if cert is not within 1 month of expiry,
+# avoiding unnecessary load on LetsEncrypt server (be a good netizen).
 
 THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
@@ -40,12 +45,23 @@ if [ -z "$CERT_DOMAIN" ]; then
     CERT_DOMAIN="$PAVICS_FQDN"
 fi
 
-EXTRA_CERTBOT_OPTS=""
-if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
-    EXTRA_CERTBOT_OPTS="--cert-name $CERT_DOMAIN"
+if [ ! -z "$FORCE_CERTBOT_E2E" ]; then
     cd $THIS_DIR/..
     ./pavics-compose.sh stop proxy
     cd $SAVED_PWD
+fi
+CERTBOT_OPTS=""
+if [ ! -z "$CERTBOT_RENEW" ]; then
+    CERTBOT_OPTS="renew"
+else
+    CERTBOT_OPTS="certonly \
+  --non-interactive \
+  --agree-tos \
+  --no-eff-email \
+  --standalone \
+  --email $SUPPORT_EMAIL \
+  --domain $CERT_DOMAIN \
+  --cert-name $CERT_DOMAIN"
 fi
 
 docker run --rm --name certbot \
@@ -54,17 +70,11 @@ docker run --rm --name certbot \
   -v "/var/log/letsencrypt:/var/log/letsencrypt" \
   -p 443:443 -p 80:80 \
   certbot/certbot:v1.3.0 \
-  certonly \
-  --non-interactive \
-  --agree-tos \
-  --no-eff-email \
-  --standalone \
-  --email $SUPPORT_EMAIL \
-  --domain $CERT_DOMAIN $EXTRA_CERTBOT_OPTS \
+  $CERTBOT_OPTS \
   "$@"
 RC=$?
 
-if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
+if [ ! -z "$FORCE_CERTBOT_E2E" ]; then
     TMP_SSL_CERT="/tmp/tmp_certbotwrapper_ssl_cert.pem"
     CERTPATH="/etc/letsencrypt/live/$CERT_DOMAIN"
     cd $THIS_DIR/..
@@ -77,7 +87,7 @@ if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
         cp -v $TMP_SSL_CERT $SSL_CERTIFICATE
     fi
     rm -v $TMP_SSL_CERT
-    if [ -z "$FORCE_CERTBOT_RENEW_NO_START_PROXY" ]; then
+    if [ -z "$FORCE_CERTBOT_E2E_NO_START_PROXY" ]; then
         ./pavics-compose.sh start proxy
     fi
     cd $SAVED_PWD

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -102,7 +102,7 @@ if [ ! -z "$FORCE_CERTBOT_E2E" ]; then
         -v "/etc/letsencrypt:/etc/letsencrypt" \
         bash \
         cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $TMP_SSL_CERT
-    if ! diff $SSL_CERTIFICATE $TMP_SSL_CERT && [ $RC -eq 0 ]; then
+    if [ -s "$TMP_SSL_CERT" ] && ! diff $SSL_CERTIFICATE $TMP_SSL_CERT && [ $RC -eq 0 ]; then
         # Only modify SSL_CERTIFICATE if there are real changes.
         cp -v $TMP_SSL_CERT $SSL_CERTIFICATE
     fi

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -64,17 +64,6 @@ docker run --rm --name certbot \
   "$@"
 RC=$?
 
-set +x
-echo "
-What to do next:
-
-CERTPATH=\"/etc/letsencrypt/live/$CERT_DOMAIN\"
-cd $THIS_DIR/..
-sudo cat \$CERTPATH/fullchain.pem \$CERTPATH/privkey.pem > $SSL_CERTIFICATE
-openssl x509 -noout -text -in $SSL_CERTIFICATE
-./pavics-compose.sh up -d
-"
-
 if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
     CERTPATH="/etc/letsencrypt/live/$CERT_DOMAIN"
     cd $THIS_DIR/..
@@ -86,6 +75,17 @@ if [ ! -z "$FORCE_CERTBOT_RENEW" ]; then
         ./pavics-compose.sh start proxy
     fi
     cd $SAVED_PWD
+else
+    set +x
+    echo "
+What to do next:
+
+CERTPATH=\"/etc/letsencrypt/live/$CERT_DOMAIN\"
+cd $THIS_DIR/..
+sudo cat \$CERTPATH/fullchain.pem \$CERTPATH/privkey.pem > $SSL_CERTIFICATE
+openssl x509 -noout -text -in $SSL_CERTIFICATE
+./pavics-compose.sh up -d
+"
 fi
 
 exit $RC

--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -25,6 +25,14 @@
 # will perform renew instead of requesting a new cert.  Renew mode will avoid
 # hitting the LetsEncrypt server if cert is not within 1 month of expiry,
 # avoiding unnecessary load on LetsEncrypt server (be a good netizen).
+#
+# Setting environment variable CERTBOTWRAPPER_LOGFILE='/path/to/logfile.log'
+# will redirect all STDOUT and STDERR to that logfile so this script will be
+# completely silent.
+
+if [ ! -z "$CERTBOTWRAPPER_LOGFILE" ]; then
+    exec >>$CERTBOTWRAPPER_LOGFILE 2>&1
+fi
 
 THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"

--- a/birdhouse/deployment/deploy.sh
+++ b/birdhouse/deployment/deploy.sh
@@ -97,6 +97,11 @@ if [ -f "$COMPOSE_DIR/docker-compose.override.yml" ]; then
     echo "WARNING: docker-compose.override.yml found, should use EXTRA_CONF_DIRS in env.local instead"
 fi
 
+# Setup COMPOSE_DIR and PWD for sourcing env.local.
+# Prevent un-expected difference when this script is run inside autodeploy
+# container and manually from the host.
+cd $COMPOSE_DIR
+
 START_TIME="`date -Isecond`"
 echo "deploy START_TIME=$START_TIME"
 

--- a/birdhouse/deployment/triggerdeploy.sh
+++ b/birdhouse/deployment/triggerdeploy.sh
@@ -48,6 +48,11 @@ if [ ! -f "$ENV_LOCAL_FILE" ]; then
     exit 2
 fi
 
+# Setup COMPOSE_DIR and PWD for sourcing env.local.
+# Prevent un-expected difference when this script is run inside autodeploy
+# container and manually from the host.
+cd $COMPOSE_DIR
+
 
 should_trigger() {
     EXTRA_REPO="`git rev-parse --show-toplevel`"

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -146,7 +146,7 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 #
 # See the job for additional possible configurations.
 #
-#. components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+#. /<absolute path>/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 
 # Public (on the internet) fully qualified domain name of this Pavics
 # installation.  This is optional so default to the same internal PAVICS_FQDN if

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -139,24 +139,12 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 #
 #export AUTODEPLOY_EXTRA_SCHEDULER_JOBS=""
 #
-# Sample scheduler to auto-renew LetsEncrypt SSL certificate
+# Load pre-configured job to auto-renew LetsEncrypt SSL certificate if a
+# LetsEncrypt SSL certificate has previously been requested.
 #
-#export AUTODEPLOY_EXTRA_SCHEDULER_JOBS="
-#- name: renew_letsencrypt_ssl
-#  comment: Auto-renew LetsEncrypt SSL certificate
-#  schedule: '22 5 * * *'
-#  command: '${PWD}/deployment/certbotwrapper'
-#  dockerargs: >-
-#    --rm --name renew_letsencrypt_ssl
-#    --volume /var/run/docker.sock:/var/run/docker.sock:ro
-#    --volume ${PWD}/..:${PWD}/..:ro
-#    --volume /var/log/PAVICS:/var/log/PAVICS:rw
-#    --volume ${SSL_CERTIFICATE}:${SSL_CERTIFICATE}:rw
-#    --env FORCE_CERTBOT_E2E=1
-#    --env CERTBOT_RENEW=1
-#    --env CERTBOTWRAPPER_LOGFILE=/var/log/PAVICS/renew_letsencrypt_ssl.log
-#  image: 'pavics/docker-compose-git:docker-18.09.7-compose-1.25.1'
-#"
+# This job performs the renewal only, not the initial request.
+#
+#. components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 
 # Public (on the internet) fully qualified domain name of this Pavics
 # installation.  This is optional so default to the same internal PAVICS_FQDN if

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -138,6 +138,24 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # Potential usages: other deployment, backup jobs on the same machine
 #
 #export AUTODEPLOY_EXTRA_SCHEDULER_JOBS=""
+#
+# Sample scheduler to auto-renew LetsEncrypt SSL certificate
+#
+#export AUTODEPLOY_EXTRA_SCHEDULER_JOBS="
+#- name: renew_letsencrypt_ssl
+#  comment: Auto-renew LetsEncrypt SSL certificate
+#  schedule: '22 5 * * *'
+#  command: '${PWD}/deployment/certbotwrapper'
+#  dockerargs: >-
+#    --rm --name renew_letsencrypt_ssl
+#    --volume /var/run/docker.sock:/var/run/docker.sock:ro
+#    --volume ${PWD}/..:${PWD}/..:ro
+#    --volume /var/log/PAVICS:/var/log/PAVICS:rw
+#    --env FORCE_CERTBOT_E2E=1
+#    --env CERTBOT_RENEW=1
+#    --env CERTBOTWRAPPER_LOGFILE=/var/log/PAVICS/renew_letsencrypt_ssl.log
+#  image: 'pavics/docker-compose-git:docker-18.09.7-compose-1.25.1'
+#"
 
 # Public (on the internet) fully qualified domain name of this Pavics
 # installation.  This is optional so default to the same internal PAVICS_FQDN if

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -6,7 +6,7 @@
 # inside a container, the environment vars do not have the same value.
 #############################################################################
 
-export SSL_CERTIFICATE="/path/to/ssl/cert.pem"  # path to the nginx ssl certificate, path and key bundle
+export SSL_CERTIFICATE="/path/to/ssl/cert.pem"  # *absolute* path to the nginx ssl certificate, path and key bundle
 export PAVICS_FQDN="hostname.domainname" # Fully qualified domain name of this Pavics installation
 export DOC_URL="https://www.example.com/" # URL where /doc gets redirected
 export MAGPIE_SECRET=itzaseekrit
@@ -143,6 +143,8 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # LetsEncrypt SSL certificate has previously been requested.
 #
 # This job performs the renewal only, not the initial request.
+#
+# See the job for additional possible configurations.
 #
 #. components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -144,7 +144,8 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 #
 # This job performs the renewal only, not the initial request.
 #
-# See the job for additional possible configurations.
+# See the job for additional possible configurations.  The "scheduler"
+# component needs to be enabled for this pre-configured job to work.
 #
 #. /<absolute path>/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -151,6 +151,7 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 #    --volume /var/run/docker.sock:/var/run/docker.sock:ro
 #    --volume ${PWD}/..:${PWD}/..:ro
 #    --volume /var/log/PAVICS:/var/log/PAVICS:rw
+#    --volume ${SSL_CERTIFICATE}:${SSL_CERTIFICATE}:rw
 #    --env FORCE_CERTBOT_E2E=1
 #    --env CERTBOT_RENEW=1
 #    --env CERTBOTWRAPPER_LOGFILE=/var/log/PAVICS/renew_letsencrypt_ssl.log

--- a/birdhouse/pavics-compose.sh
+++ b/birdhouse/pavics-compose.sh
@@ -50,7 +50,13 @@ OPTIONAL_VARS='
 
 # we switch to the real directory of the script, so it still works when used from $PATH
 # tip: ln -s /path/to/pavics-compose.sh ~/bin/
+# Setup PWD for sourcing env.local.
 cd $(dirname $(readlink -f $0 || realpath $0))
+
+# Setup COMPOSE_DIR for sourcing env.local.
+# Prevent un-expected difference when this script is run inside autodeploy
+# container and manually from the host.
+COMPOSE_DIR="`pwd`"
 
 . ./default.env
 

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -17,6 +17,11 @@ EOF
     if [ -n "$LETSENCRYPT_EMAIL" ]; then
     cat <<EOF >> env.local
 export SUPPORT_EMAIL="$LETSENCRYPT_EMAIL"
+
+# Modify schedule so test systems do not hit LetsEncrypt at the same time as
+# prod systems to avoid loading LetsEncrypt server (be a nice netizen).
+RENEW_LETSENCRYPT_SSL_SCHEDULE="22 9 * * *"  # UTC
+. components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 EOF
     elif [ -n "$KITENAME" -a -n "$KITESUBDOMAIN" ]; then
     cat <<EOF >> env.local

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -28,7 +28,7 @@ if [ ! -f certkey.pem ]; then
     . ./env.local
     if [ -n "$LETSENCRYPT_EMAIL" ]; then
         FORCE_CERTBOT_RENEW=1 FORCE_CERTBOT_RENEW_NO_START_PROXY=1 \
-            deployment/certbotwrapper --cert-name $PAVICS_FQDN
+            deployment/certbotwrapper
     else
         openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem \
             -subj "/C=CA/ST=Quebec/L=Montreal/O=RnD/CN=${VM_HOSTNAME}.$VM_DOMAIN"

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -27,7 +27,7 @@ fi
 if [ ! -f certkey.pem ]; then
     . ./env.local
     if [ -n "$LETSENCRYPT_EMAIL" ]; then
-        FORCE_CERTBOT_RENEW=1 FORCE_CERTBOT_RENEW_NO_START_PROXY=1 \
+        FORCE_CERTBOT_E2E=1 FORCE_CERTBOT_E2E_NO_START_PROXY=1 \
             deployment/certbotwrapper
     else
         openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem \

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -1,11 +1,16 @@
 #!/bin/sh -x
 
+if [ -z "$SSL_CERTIFICATE" ]; then
+    # Overridable
+    SSL_CERTIFICATE="/home/vagrant/certkey.pem"
+fi
+
 if [ ! -f env.local ]; then
     cp env.local.example env.local
     cat <<EOF >> env.local
 
 # override with values needed for vagrant
-export SSL_CERTIFICATE='./certkey.pem'  # path to the nginx ssl certificate, path and key bundle
+export SSL_CERTIFICATE='$SSL_CERTIFICATE'  # *absolute* path to the nginx ssl certificate, path and key bundle
 export PAVICS_FQDN='${VM_HOSTNAME}.$VM_DOMAIN' # Fully qualified domain name of this Pavics installation
 EOF
 
@@ -24,7 +29,7 @@ else
     echo "existing env.local file, not overriding"
 fi
 
-if [ ! -f certkey.pem ]; then
+if [ ! -f "$SSL_CERTIFICATE" ]; then
     . ./env.local
     if [ -n "$LETSENCRYPT_EMAIL" ]; then
         FORCE_CERTBOT_E2E=1 FORCE_CERTBOT_E2E_NO_START_PROXY=1 \
@@ -32,8 +37,8 @@ if [ ! -f certkey.pem ]; then
     else
         openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem \
             -subj "/C=CA/ST=Quebec/L=Montreal/O=RnD/CN=${VM_HOSTNAME}.$VM_DOMAIN"
-        cp cert.pem certkey.pem
-        cat key.pem >> certkey.pem
+        cp cert.pem "$SSL_CERTIFICATE"
+        cat key.pem >> "$SSL_CERTIFICATE"
         if [ -z "$VERIFY_SSL" ]; then
             cat <<EOF >> env.local
 export VERIFY_SSL="false"
@@ -41,7 +46,7 @@ EOF
         fi
     fi
 else
-    echo "existing certkey.pem file, not overriding"
+    echo "existing '$SSL_CERTIFICATE' file, not overriding"
 fi
 
 ./pavics-compose.sh up -d

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -26,6 +26,10 @@ export SUPPORT_EMAIL="$LETSENCRYPT_EMAIL"
 # Modify schedule so test systems do not hit LetsEncrypt at the same time as
 # prod systems to avoid loading LetsEncrypt server (be a nice netizen).
 RENEW_LETSENCRYPT_SSL_SCHEDULE="22 9 * * *"  # UTC
+
+# This repo will be volume-mount at /vagrant so can not go higher.
+RENEW_LETSENCRYPT_SSL_NUM_PARENTS_MOUNT="/"
+
 . $PWD/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 EOF
     elif [ -n "$KITENAME" -a -n "$KITESUBDOMAIN" ]; then

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -21,7 +21,7 @@ export SUPPORT_EMAIL="$LETSENCRYPT_EMAIL"
 # Modify schedule so test systems do not hit LetsEncrypt at the same time as
 # prod systems to avoid loading LetsEncrypt server (be a nice netizen).
 RENEW_LETSENCRYPT_SSL_SCHEDULE="22 9 * * *"  # UTC
-. components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+. $PWD/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 EOF
     elif [ -n "$KITENAME" -a -n "$KITESUBDOMAIN" ]; then
     cat <<EOF >> env.local

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -27,10 +27,8 @@ fi
 if [ ! -f certkey.pem ]; then
     . ./env.local
     if [ -n "$LETSENCRYPT_EMAIL" ]; then
-        ./pavics-compose.sh stop proxy
-        deployment/certbotwrapper --cert-name $PAVICS_FQDN
-        CERTPATH="/etc/letsencrypt/live/$PAVICS_FQDN"
-        sudo cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $SSL_CERTIFICATE
+        FORCE_CERTBOT_RENEW=1 FORCE_CERTBOT_RENEW_NO_START_PROXY=1 \
+            deployment/certbotwrapper --cert-name $PAVICS_FQDN
     else
         openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem \
             -subj "/C=CA/ST=Quebec/L=Montreal/O=RnD/CN=${VM_HOSTNAME}.$VM_DOMAIN"

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -1,7 +1,12 @@
 #!/bin/sh -x
 
+if [ -f env.local ]; then
+    # Get SSL_CERTIFICATE from existing env.local.
+    . ./env.local
+fi
+
 if [ -z "$SSL_CERTIFICATE" ]; then
-    # Overridable
+    # Overridable by existing env.local or existing env var.
     SSL_CERTIFICATE="/home/vagrant/certkey.pem"
 fi
 

--- a/vagrant_variables.yml.example
+++ b/vagrant_variables.yml.example
@@ -32,8 +32,9 @@ domain: ouranos.ca
 # - { srcdir: "/data/datasets-priv", destdir: "/data/datasetsPrivate" }
 # - { srcdir: "C:/data/datasets", destdir: "/data/datasets" }
 
-# If you want to provide a SSL certificate yourself, name it 'certkey.pem' and
-# it won't be overriden, see vagrant-utils/configure-pavics.sh.  Otherwise one
+# If you want to provide a SSL certificate yourself, name it
+# '/home/vagrant/certkey.pem' and it won't be overriden, see
+# vagrant-utils/configure-pavics.sh.  Otherwise one
 # will be generated automatically for you.
 
 # If you want to provide an env.local yourself, just create it and it won't be


### PR DESCRIPTION
Auto-renew LetsEncrypt SSL certificate leveraging the cron jobs of the "scheduler" component.  Meaning this feature is self-contained in the PAVICS stack, no dependency on the host's cron jobs.

Default behavior is to attempt renewal everyday.  `certbot` client in `renew` mode will not hit LetsEncrypt server if renewal is not allowed (not within 1 month of expiry) so this should not put too much stress on LetsEncrypt server.  However, this gives us 30 retry opportunities (1 month) if something is wrong on the first try.

All configs are centralized in `env.local`, easing reproducibility on multiple deployments of PAVICS and following infra-as-code.

User can still perform the renewal manually by calling `certbotwrapper` directly. User is not forced to enable the "scheduler" component but will miss out on the automatic renewal.

Documentation for activating this automatic renewal is in `env.local.example`.

See `vagrant-utils/configure-pavics.sh` for how it's being used for real in a Vagrant box.

Logs (`/var/log/PAVICS/renew_letsencrypt_ssl.log`) when no renewal is necessary, proxy down time less than 1 minute:
[certbot-renew-no-ops.txt](https://github.com/bird-house/birdhouse-deploy/files/5209376/certbot-renew-no-ops.txt)

Logs when renewal is needed but failed due to firewall, `certbot` adds a random delay so proxy could be down up to 10 mins:
[certbot-renew-error.txt](https://github.com/bird-house/birdhouse-deploy/files/5209403/certbot-renew-error.txt)

Logs when renewal is successful, again proxy could be down up to 10 mins due to random delay by `certbot` client:
[certbot-renew-success-in-2-run-after-file-copy-fix.txt](https://github.com/bird-house/birdhouse-deploy/files/5209924/certbot-renew-success-in-2-run-after-file-copy-fix.txt)





