### PR TITLE
jupyter: new updated image with new handcalcs package

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200803"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200914.1"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.2"
 


### PR DESCRIPTION
Matching PR to deploy the new jupyter image to PAVICS.

See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/50 (commit https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/02333bfa11931f4a0b7c9607b88904bd063bed70)
that built the new image with the detailed change vs the previous image.

Add handcalcs https://github.com/connorferster/handcalcs/ and unpin hvplot
since pinning did not solve violin plot issue, see this comment
https://github.com/bird-house/birdhouse-deploy/pull/63#issuecomment-668270608

Successful Jenkins build
http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/periodic-rebuild-and-add-handcalcs/1/console

Noticeable changes:
```diff
>     - handcalcs==0.8.1

<     - xclim==0.18.0
>     - xclim==0.19.0

<   - hvplot=0.5.2=py_0
>   - hvplot=0.6.0=pyh9f0ad1d_0

<   - dask=2.22.0=py_0
>   - dask=2.26.0=py_0

<   - bokeh=2.1.1=py37hc8dfbb8_0
>   - bokeh=2.2.1=py37hc8dfbb8_0

<   - numba=0.50.1=py37h0da4684_1
>   - numba=0.51.2=py37h9fdb41a_0
```