### PR TITLE
jupyter: new build for new xclim with fix for missing clisops dependency

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200914.1"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200925.1"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.2"
 


### PR DESCRIPTION
Matching PR to deploy new Jupyter env from PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/52 (commit https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/18c8397ff30c9ba4b9f56896df4c898c7e9a356e).

Deployed to https://medus.ouranos.ca/jupyter/ for testing.

Relevant changes:
```diff
>   - clisops=0.3.1=pyh32f6830_1

<     - xclim==0.19.0
>   - xclim=0.20.0=py_0

<   - xarray=0.16.0py_0
>   - xarray=0.16.1=py_0

<   - dask=2.26.0=py_0
>   - dask=2.27.0=py_0

<   - fiona=1.8.13=py37h0492a4a_1
>   - fiona=1.8.17=py37ha3d844c_0

<   - gdal=3.0.4=py37h4b180d9_10
>   - gdal=3.1.2=py37h518339e_2

<   - jupyter_server=0.1.1=py37_0
>   - jupyter_server=1.0.1=py37hc8dfbb8_0

>     - jupyternotify==0.1.15

>     - pytest-tornasync==0.6.0.post2
```

See PR above for full changes.