### PR TITLE
twitcher: temp fix for slow download, not really working

### DIFF
--- a/birdhouse/config/twitcher/increase-bufferedresponse-chunk-size.diff
+++ b/birdhouse/config/twitcher/increase-bufferedresponse-chunk-size.diff
@@ -1,0 +1,13 @@
+# Temporary work-around for https://github.com/bird-house/twitcher/issues/97
+# until a final clean solution is available.
+--- /opt/birdhouse/src/twitcher/twitcher/owsproxy.py.orig
++++ /opt/birdhouse/src/twitcher/twitcher/owsproxy.py
+@@ -58,7 +58,7 @@
+         self.resp = resp
+ 
+     def __iter__(self):
+-        return self.resp.iter_content(64 * 1024)
++        return self.resp.iter_content(64 * 1024 * 1024)
+ 
+ 
+ def _send_request(request, service, extra_path=None, request_params=None):

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -320,7 +320,8 @@ services:
       - postgres-magpie
     volumes:
       - ./config/twitcher/twitcher.ini:/opt/birdhouse/src/twitcher/twitcher.ini
-    command: "pserve /opt/birdhouse/src/twitcher/twitcher.ini"
+      - ./config/twitcher/increase-bufferedresponse-chunk-size.diff:/increase-bufferedresponse-chunk-size.diff:ro
+    command: "bash -c 'set -x; patch -N -p0 < /increase-bufferedresponse-chunk-size.diff; pserve /opt/birdhouse/src/twitcher/twitcher.ini'"
     restart: always
 
   postgres-magpie:


### PR DESCRIPTION
Possible temporary work-around for https://github.com/bird-house/twitcher/issues/97.  The chunk size is bumped 1000 times.

I think the proper fix is not here because the performance improvement is very little, see test notebook in this gist
https://gist.github.com/tlvu/17026b820dc5ba941895914e000b5280

I am not even sure if it is worth to merge this PR.  

I would keep this PR as proof of progress on that issue.

Here is the logs showing the patch is applied correctly.

```
$ docker logs twitcher 2>&1 | head -5
+ patch -N -p0
patching file /opt/birdhouse/src/twitcher/twitcher/owsproxy.py
+ pserve /opt/birdhouse/src/twitcher/twitcher.ini
2020-10-22 17:47:51,756 INFO  [TWITCHER:60][MainThread] Using adapter: '<class 'magpie.adapter.MagpieAdapter'>'
2020-10-22 17:47:51,757 INFO  [TWITCHER:140][MainThread] Loading MagpieAdapter owsproxy config
```

FYI @tlogan2000 @aulemahal