### PR TITLE
jupyter: new image for python 3.8, new xclim and memory_profiler

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:200925.1"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:201026"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.2"
 


### PR DESCRIPTION
Matching PR to deploy the new Jupyter image to PAVICS.

Deployed to https://medus.ouranos.ca/jupyter/ for testing.  This one has python 3.8, might worth some manual testing.

Relevant changes:
```diff
<   - python=3.7.8=h6f2ec95_1_cpython
>   - python=3.8.6=h852b56e_0_cpython

<   - xclim=0.20.0=py_0
>   - xclim=0.21.0=py_0

<   - dask=2.27.0=py_0
>   - dask=2.30.0=py_0

<   - rioxarray=0.0.31=py_0
>   - rioxarray=0.1.0=py_0

>   - memory_profiler=0.58.0=py_0
```

More info, see PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/53 (commit https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/f07f1657ed13a0ed92854c5d01f9d3ed785e870d)