### PR TITLE
Prepare fresh deployment for automated tests

### DIFF
--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -112,6 +112,10 @@ For that test suite to pass, run the script
 [`bootstrap-instance-for-testsuite`](scripts/bootstrap-instance-for-testsuite)
 to prepare your new instance.  Further documentation inside the script.
 
+Optional component
+[all-public-access](optional-components#give-public-access-to-all-resources-for-testing-purposes)
+also need to be enabled in `env.local`.
+
 
 ## Vagrant instructions
 

--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -102,6 +102,17 @@ Manual instructions:
 * Click "Add User".
 
 
+### Prepare instance to run automated end-to-end test suite
+
+An end-to-end integration test suite is available at
+https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests with pre-configured
+Jenkins at https://github.com/Ouranosinc/jenkins-config.
+
+For that test suite to pass, run the script
+[`bootstrap-instance-for-testsuite`](scripts/bootstrap-instance-for-testsuite)
+to prepare your new instance.  Further documentation inside the script.
+
+
 ## Vagrant instructions
 
 Vagrant allows us to quickly spin up a VM to easily reproduce the runtime

--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -121,6 +121,11 @@ https://github.com/Ouranosinc/pavics-sdi/blob/master/docs/source/notebooks/esgf-
 part of test suite.  ESGF credentails can be given to Jenkins via
 https://github.com/Ouranosinc/jenkins-config/blob/aafaf6c33ea60faede2a32850604c07c901189e8/env.local.example#L11-L13
 
+The canarie monitoring link
+`https://<PAVICS_FQDN>/canarie/node/service/stats` can be used to confirm the
+instance is ready to run the automated end-to-end test suite.  That link should
+return the HTTP response code `200`.
+
 
 ## Vagrant instructions
 

--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -116,6 +116,11 @@ Optional component
 [all-public-access](optional-components#give-public-access-to-all-resources-for-testing-purposes)
 also need to be enabled in `env.local`.
 
+ESGF login is also needed for
+https://github.com/Ouranosinc/pavics-sdi/blob/master/docs/source/notebooks/esgf-dap.ipynb
+part of test suite.  ESGF credentails can be given to Jenkins via
+https://github.com/Ouranosinc/jenkins-config/blob/aafaf6c33ea60faede2a32850604c07c901189e8/env.local.example#L11-L13
+
 
 ## Vagrant instructions
 

--- a/birdhouse/README.md
+++ b/birdhouse/README.md
@@ -102,7 +102,7 @@ Manual instructions:
 * Click "Add User".
 
 
-### Prepare instance to run automated end-to-end test suite
+### Optional: prepare instance to run automated end-to-end test suite
 
 An end-to-end integration test suite is available at
 https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests with pre-configured

--- a/birdhouse/config/canarie-api/docker_configuration.py.template
+++ b/birdhouse/config/canarie-api/docker_configuration.py.template
@@ -84,10 +84,10 @@ SERVICES = {
             },
             'Solr': {
                 'request': {
-                    'url': 'http://${PAVICS_FQDN}:8983/solr/birdhouse/select?q=CMIP5&fq=model=CanESM2&fq=experiment:rcp85&wt=json'
+                    'url': 'http://${PAVICS_FQDN}:8983/solr/birdhouse/select?q=CMIP5&fq=model:MPI-ESM-MR&fq=experiment:rcp45&fq=variable:tasmax&fq=institute:MPI-M&fq=frequency:mon&wt=json'
                 },
                 'response': {
-                    'text': '.*catalog_url\":\".+${CMIP5_THREDDS_ROOT}/CanESM2/rcp85/.*/catalog.xml.*'
+                    'text': '.*catalog_url\":\".+/testdata/flyingpigeon/cmip5.*/catalog.xml.*'
                 }
             },
             'Thredds': {

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -89,3 +89,10 @@ c.Authenticator.admin_users = ${JUPYTERHUB_ADMIN_USERS}
 # MagpieAuthenticator.refresh_user() (see
 # https://github.com/Ouranosinc/jupyterhub/issues/2)
 c.Authenticator.refresh_pre_spawn = True
+
+## Blacklist of usernames that are not allowed to log in.
+# https://jupyterhub.readthedocs.io/en/stable/api/auth.html
+#
+# For security reasons, block user with known hardcoded public password.
+c.Authenticator.blacklist = set(['authtest'])  # v0.9+
+c.Authenticator.blocked_users = set(['authtest'])  # v1.2+

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -70,7 +70,13 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 #
 #export EXTRA_CONF_DIRS="/path/to/dir1 ./path/to/dir2 dir3 dir4"
 #export EXTRA_CONF_DIRS="./optional-components/canarie-api-full-monitoring
-#    ./optional-components/emu /path/to/private-config-repo"
+#    ./optional-components/emu
+#    ./optional-components/testthredds
+#    ./optional-components/generic_bird
+#    ./optional-components/all-public-access
+#    ./components/scheduler
+#    ./components/monitoring
+#    /path/to/private-config-repo"
 
 # Extra repos, than the current repo, the autodeploy should keep up-to-date.
 # Any changes to these extra repos will also trigger autodeploy.

--- a/birdhouse/optional-components/README.md
+++ b/birdhouse/optional-components/README.md
@@ -120,9 +120,12 @@ By enabling this component, all WPS services and data on Thredds are completely 
 Once enabled, if you need to revert the change, you have to do it manually by logging into Magpie. 
 Just disabling this component will not revert the change.
 
+This optional component is required for the test suite at
+https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests.
+
 How to enable in `env.local` (a copy from
 [`env.local.example`](../env.local.example)):
 
 * Add `./optional-components/all-public-access` to `EXTRA_CONF_DIRS`.
 
-The anonymous user will now have all the permissions described in `./optional-components/all-public-access/all-public-access-magpie-permission.cfg`.
+The anonymous user will now have all the permissions described in [`./optional-components/all-public-access/all-public-access-magpie-permission.cfg`](all-public-access/all-public-access-magpie-permission.cfg).

--- a/birdhouse/scripts/bootstrap-instance-for-testsuite
+++ b/birdhouse/scripts/bootstrap-instance-for-testsuite
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Bootstrap fresh new PAVICS instance to run testsuite at
+# https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests.
+#
+# This is a stable interface for test automation shielding it from knowing the
+# intimate details of how to bootstrap a fresh new instance.
+#
+
+THIS_FILE="`realpath "$0"`"
+THIS_DIR="`dirname "$THIS_FILE"`"
+
+set -x
+# Populate test .nc file on Thredds.
+$THIS_DIR/bootstrap-testdata
+
+# Index Thredds catalog.
+$THIS_DIR/trigger-pavicscrawler
+
+# For crawler to complete, assuming minimal dataset from bootstrap-testdata so
+# should be super fast to finish crawling.
+sleep 5
+
+# Create test user.
+$THIS_DIR/create-magpie-authtest-user

--- a/birdhouse/scripts/bootstrap-instance-for-testsuite
+++ b/birdhouse/scripts/bootstrap-instance-for-testsuite
@@ -5,6 +5,9 @@
 # This is a stable interface for test automation shielding it from knowing the
 # intimate details of how to bootstrap a fresh new instance.
 #
+# Assume PAVICS instance is already fully up (`./pavics-compose.sh up -d` has
+# been called).
+#
 
 THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
@@ -22,3 +25,10 @@ sleep 5
 
 # Create test user.
 $THIS_DIR/create-magpie-authtest-user
+
+echo "
+\$ curl --include --silent https://<PAVICS_FQDN>/canarie/node/service/stats | head
+
+Should return the HTTP response code 200 to confirm instance is ready to run
+the testsuite.
+"

--- a/birdhouse/scripts/bootstrap-testdata
+++ b/birdhouse/scripts/bootstrap-testdata
@@ -1,0 +1,34 @@
+#!/bin/sh -x
+# Bootstrap mininum test data on Thredds.
+
+# To be run locally on the host running Thredds.  Will populate test data files
+# under DATASET_ROOT, customizable by env var.
+
+
+if [ -z "$DATASET_ROOT" ]; then
+    DATASET_ROOT="/data/datasets"
+fi
+
+FROM_SERVER="https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse"
+
+FILE_LIST="
+nrcan/nrcan_canada_daily/tasmin/nrcan_canada_daily_tasmin_2013.nc
+testdata/flyingpigeon/cmip3/pr.sresa2.miub_echo_g.run1.atm.da.nc
+testdata/flyingpigeon/cmip3/tasmin.sresa2.miub_echo_g.run1.atm.da.nc
+testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r1i1p1_200601-200612.nc
+testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc
+testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc
+testdata/ta_Amon_MRI-CGCM3_decadal1980_r1i1p1_199101-200012.nc
+"
+
+cd "$DATASET_ROOT"
+
+for afile in $FILE_LIST; do
+    if [ ! -f "$afile" ]; then
+        PARENT_DIRS="`dirname "$afile"`"
+        if [ ! -d "$PARENT_DIRS" ]; then
+            mkdir -p "$PARENT_DIRS"
+        fi
+        curl "$FROM_SERVER/$afile" --output "$afile"
+    fi
+done

--- a/birdhouse/scripts/bootstrap-testdata
+++ b/birdhouse/scripts/bootstrap-testdata
@@ -1,6 +1,7 @@
 #!/bin/sh -x
 # Bootstrap mininum test data on Thredds.
-
+# To run testsuite in https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests.
+#
 # To be run locally on the host running Thredds.  Will populate test data files
 # under DATASET_ROOT, customizable by env var.
 

--- a/birdhouse/scripts/create-magpie-authtest-user
+++ b/birdhouse/scripts/create-magpie-authtest-user
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Create authtest user for testsuite at
+# https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests.
+#
+
+THIS_FILE="`realpath "$0"`"
+THIS_DIR="`dirname "$THIS_FILE"`"
+
+TMP_CONFIG_FILE="/tmp/create-magpie-authtest-user.yml"
+
+cat <<__OEF__ > $TMP_CONFIG_FILE
+users:
+   - username: authtest
+     password: authtest
+     email: authtest@example.com
+     group: anonymous
+__OEF__
+
+set -x
+cat $TMP_CONFIG_FILE
+MAGPIE_CLI_CONF="$TMP_CONFIG_FILE" $THIS_DIR/create-magpie-users
+rm -v $TMP_CONFIG_FILE

--- a/birdhouse/scripts/create-magpie-authtest-user
+++ b/birdhouse/scripts/create-magpie-authtest-user
@@ -2,6 +2,8 @@
 # Create authtest user for testsuite at
 # https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests.
 #
+# Options:
+#   -d: delete user 'authtest' instead of creating it
 
 THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
@@ -18,5 +20,5 @@ __OEF__
 
 set -x
 cat $TMP_CONFIG_FILE
-MAGPIE_CLI_CONF="$TMP_CONFIG_FILE" $THIS_DIR/create-magpie-users
+MAGPIE_CLI_CONF="$TMP_CONFIG_FILE" $THIS_DIR/create-magpie-users "$@"
 rm -v $TMP_CONFIG_FILE

--- a/birdhouse/scripts/create-magpie-users
+++ b/birdhouse/scripts/create-magpie-users
@@ -1,7 +1,8 @@
 #!/bin/sh
 #
 # Batch create or delete magpie users using config file at
-# /tmp/create_magpie_users/config.yml (harcoded path).
+# /tmp/create_magpie_users/config.yml (configurable using MAGPIE_CLI_CONF env
+# var).
 #
 # Should run from checkout on same host running PAVICS to have access to
 # env.local file for Magpie credentials.  Else these can be provided via
@@ -92,6 +93,10 @@ if [ -z "$MAGPIE_CLI_OUTPUT_DIR" ]; then
     MAGPIE_CLI_OUTPUT_DIR="/tmp/create_magpie_users"
 fi
 
+if [ -z "$MAGPIE_CLI_CONF" ]; then
+    MAGPIE_CLI_CONF="$MAGPIE_CLI_OUTPUT_DIR/config.xml"
+fi
+
 if [ -z "$MAGPIE_CLI_IMAGE" ]; then
     MAGPIE_CLI_IMAGE="pavics/magpie:2.0.1"
 fi
@@ -101,10 +106,11 @@ fi
 
 
 BASE_CMD="docker run --rm -it --name create_magpie_users \
+    -v $MAGPIE_CLI_CONF:$MAGPIE_CLI_CONF:ro \
     -v $MAGPIE_CLI_OUTPUT_DIR:$MAGPIE_CLI_OUTPUT_DIR:rw \
     $DOCKER_EXTRA_OPTS \
     $MAGPIE_CLI_IMAGE magpie_cli batch_update_users $MAGPIE_SERVER_URL $MAGPIE_CLI_USER $MAGPIE_CLI_PASS"
 
 set -x
 
-$BASE_CMD -f $MAGPIE_CLI_OUTPUT_DIR/config.yml -o $MAGPIE_CLI_OUTPUT_DIR/ "$@"
+$BASE_CMD -f $MAGPIE_CLI_CONF -o $MAGPIE_CLI_OUTPUT_DIR/ "$@"

--- a/birdhouse/scripts/create-magpie-users
+++ b/birdhouse/scripts/create-magpie-users
@@ -105,7 +105,7 @@ fi
 ##############################################################################
 
 
-BASE_CMD="docker run --rm -it --name create_magpie_users \
+BASE_CMD="docker run --rm --name create_magpie_users \
     -v $MAGPIE_CLI_CONF:$MAGPIE_CLI_CONF:ro \
     -v $MAGPIE_CLI_OUTPUT_DIR:$MAGPIE_CLI_OUTPUT_DIR:rw \
     $DOCKER_EXTRA_OPTS \

--- a/birdhouse/scripts/create-magpie-users
+++ b/birdhouse/scripts/create-magpie-users
@@ -94,7 +94,7 @@ if [ -z "$MAGPIE_CLI_OUTPUT_DIR" ]; then
 fi
 
 if [ -z "$MAGPIE_CLI_CONF" ]; then
-    MAGPIE_CLI_CONF="$MAGPIE_CLI_OUTPUT_DIR/config.xml"
+    MAGPIE_CLI_CONF="$MAGPIE_CLI_OUTPUT_DIR/config.yml"
 fi
 
 if [ -z "$MAGPIE_CLI_IMAGE" ]; then

--- a/birdhouse/scripts/trigger-pavicscrawler
+++ b/birdhouse/scripts/trigger-pavicscrawler
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Trigger pavicscrawler on local PAVICS host.
+#
+# pavicscrawler is a method of the catalog WPS service to index Thredds
+# catalog into Solr DB for quick searching.
+#
+# To crawl only 1 file:
+#   trigger-pavicscrawler target_files=birdhouse/testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc
+#
+# To crawl only 1 dir:
+#   trigger-pavicscrawler target_files=birdhouse/testdata
+#
+# Set env var PAVICS_CRAWLER_HOST to target different PAVICS host.
+
+THIS_FILE="`realpath "$0"`"
+THIS_DIR="`dirname "$THIS_FILE"`"
+COMPOSE_DIR="`dirname "$THIS_DIR"`"
+
+if [ -f "$COMPOSE_DIR/env.local" ]; then
+    # Get PAVICS_FQDN
+    . $COMPOSE_DIR/env.local
+fi
+
+# Allow override using same name env var.
+if [ -z "$PAVICS_CRAWLER_HOST" ]; then
+    PAVICS_CRAWLER_HOST="$PAVICS_FQDN"
+fi
+
+set -x
+
+curl --include "http://${PAVICS_CRAWLER_HOST}:8086/pywps?service=WPS&request=execute&version=1.0.0&identifier=pavicrawler&storeExecuteResponse=true&status=true&DataInputs=$*"
+
+set +x
+
+echo "
+NOTE the
+statusLocation=\"https://HOST/wpsoutputs/catalog/e31a4914-16e8-11ea-aab9-0242ac130014.xml\"
+returned in the XML body of the curl command. The status of the crawl,
+whether ongoing, failed or success will be in that link.
+
+Once crawler is done, go check the Solr DB at
+http://$PAVICS_CRAWLER_HOST:8983/solr/#/birdhouse/query for content inserted by the
+crawler.  Just click on \"Execute Query\".
+"


### PR DESCRIPTION
@MatProv is building an automated pipeline that will provision and deploy a full PAVICS stack and run our Jenkins test suite for each PR here.

So each time his new fresh instance comes up, there are a few steps to perform for the Jenkins test suite to pass.  Those steps are captured in `scripts/bootstrap-instance-for-testsuite`.  @MatProv please call this script, do not perform each steps yourself so any future changes to those steps will be transparent to your pipeline.  A new optional components was also required, done in PR https://github.com/bird-house/birdhouse-deploy/pull/92.

For security reasons, Jupyterhub will block the test user to login since its password is known publicly.

Each step are also in their own script so can be assembled differently to prepare the fresh instance if desired.

Solr query in the canarie monitoring also updated to target the minimal dataset from `bootstrap-testdata` so the canarie monitoring page works on all PAVICS deployment (fixes https://github.com/bird-house/birdhouse-deploy/issues/6).  @MatProv you can use this canarie monitoring page (ex: https://pavics.ouranos.ca/canarie/node/service/status) to confirm the fresh instance is ready to run the Jenkins test suite.