### PR TITLE
changed authtest user password

### DIFF
--- a/birdhouse/scripts/create-magpie-authtest-user
+++ b/birdhouse/scripts/create-magpie-authtest-user
@@ -13,7 +13,7 @@ TMP_CONFIG_FILE="/tmp/create-magpie-authtest-user.yml"
 cat <<__OEF__ > $TMP_CONFIG_FILE
 users:
    - username: authtest
-     password: authtest
+     password: authtest1234
      email: authtest@example.com
      group: anonymous
 __OEF__


### PR DESCRIPTION
Changed `authtest` user password, since magpie 3.1.0 now requires 12 characters password