### PR TITLE
jupyter: new image with 4 new extensions

### DIFF
--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -37,6 +37,14 @@ c.DockerSpawner.environment = {
 
 c.DockerSpawner.volumes = {host_user_data_dir: container_workspace_dir}
 
+container_gdrive_settings_path = join(container_home_dir, ".jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings")
+host_gdrive_settings_path = os.environ['JUPYTER_GOOGLE_DRIVE_SETTINGS']
+
+c.DockerSpawner.volumes[host_gdrive_settings_path] = {
+    "bind": container_gdrive_settings_path,
+    "mode": "ro"
+}
+
 host_tutorial_notebooks_dir = join(jupyterhub_data_dir, "tutorial-notebooks")
 c.DockerSpawner.volumes[host_tutorial_notebooks_dir] = {
     "bind": join(notebook_dir, "tutorial-notebooks"),

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -40,10 +40,11 @@ c.DockerSpawner.volumes = {host_user_data_dir: container_workspace_dir}
 container_gdrive_settings_path = join(container_home_dir, ".jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings")
 host_gdrive_settings_path = os.environ['JUPYTER_GOOGLE_DRIVE_SETTINGS']
 
-c.DockerSpawner.volumes[host_gdrive_settings_path] = {
-    "bind": container_gdrive_settings_path,
-    "mode": "ro"
-}
+if len(host_gdrive_settings_path) > 0:
+	c.DockerSpawner.volumes[host_gdrive_settings_path] = {
+		"bind": container_gdrive_settings_path,
+		"mode": "ro"
+	}
 
 host_tutorial_notebooks_dir = join(jupyterhub_data_dir, "tutorial-notebooks")
 c.DockerSpawner.volumes[host_tutorial_notebooks_dir] = {

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:201026"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:201111"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.3"
 

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -11,6 +11,9 @@ export THREDDS_IMAGE="unidata/thredds-docker:4.6.14"
 # Folder on the host to persist Jupyter user data (noteboooks, HOME settings)
 export JUPYTERHUB_USER_DATA_DIR="/data/jupyterhub_user_data"
 
+# Path to the file containing the clientID for the google drive extension for jupyterlab
+export JUPYTER_GOOGLE_DRIVE_SETTINGS=""
+
 # Jupyter public demo account with limited computing resources for security reasons
 export JUPYTER_DEMO_USER="demo"
 # Changing any limits requires restarting the jupyter user server

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -352,6 +352,7 @@ services:
       JUPYTER_DEMO_USER: ${JUPYTER_DEMO_USER}
       JUPYTER_DEMO_USER_MEM_LIMIT: ${JUPYTER_DEMO_USER_MEM_LIMIT}
       JUPYTER_DEMO_USER_CPU_LIMIT: ${JUPYTER_DEMO_USER_CPU_LIMIT}
+      JUPYTER_GOOGLE_DRIVE_SETTINGS: ${JUPYTER_GOOGLE_DRIVE_SETTINGS}
     volumes:
       - ./config/jupyterhub/jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro
       - ./config/jupyterhub/custom_templates:/custom_templates:ro

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -175,6 +175,10 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # and this folder will be mounted when he logs into JupyterHub.
 #export JUPYTERHUB_USER_DATA_DIR=/data/jupyterhub_user_data
 
+# Path to the file containing the clientID for the google drive extension for jupyterlab
+# This file will be mounted into JupyterLab instances
+#export JUPYTER_GOOGLE_DRIVE_SETTINGS=
+
 # Extra PyWPS config for **all** WPS services (currently only Flyingpigeon, Finch and Raven supported).
 # export EXTRA_PYWPS_CONFIG="
 # [logging]

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -176,7 +176,9 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 #export JUPYTERHUB_USER_DATA_DIR=/data/jupyterhub_user_data
 
 # Path to the file containing the clientID for the google drive extension for jupyterlab
-# This file will be mounted into JupyterLab instances
+# This file will be mounted into JupyterLab instances.
+# It should contain the following data : {"clientId":"<add_client_id_here>"}
+# To setup a project and find the clientID, check the doc at : https://github.com/jupyterlab/jupyterlab-google-drive/blob/master/docs/setup.md
 #export JUPYTER_GOOGLE_DRIVE_SETTINGS=
 
 # Extra PyWPS config for **all** WPS services (currently only Flyingpigeon, Finch and Raven supported).


### PR DESCRIPTION
The google drive extension for JupyterLab requires a settings file containing the clientid of the project created in developers.google.com, which give authorization to use google drive.

This PR's role is to include this file in the birdhouse configs.

Matching PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/54 (commit https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/5d5a9aa2251386378406efb5b414b3aa6db0b37e) for the new image with 4 new extensions: jupytext, jupyterlab-google-drive, jupyter_conda and jupyterlab-git

Matching PR https://github.com/Ouranosinc/pavics-sdi/pull/185 for documention about the new extensions.