### PR TITLE
Various small fixes

### DIFF
--- a/birdhouse/components/monitoring/docker-compose-extra.yml
+++ b/birdhouse/components/monitoring/docker-compose-extra.yml
@@ -15,7 +15,7 @@ services:
       - 9999:8080
     devices:
       - /dev/kmsg
-    restart: unless-stopped
+    restart: always
 
   # https://github.com/prometheus/node_exporter
   # Collect system-wide metrics.
@@ -29,7 +29,7 @@ services:
     network_mode: "host"
     pid: "host"
     command: --path.rootfs=/host
-    restart: unless-stopped
+    restart: always
 
   # https://prometheus.io/docs/prometheus/latest/installation
   # Monitor and store collected metrics.
@@ -52,7 +52,7 @@ services:
       - --storage.tsdb.retention.time=90d
       # wrong default was http://container-hash:9090/
       - --web.external-url=http://${PAVICS_FQDN}:9090/
-    restart: unless-stopped
+    restart: always
 
   # https://grafana.com/docs/grafana/latest/installation/docker/
   # https://grafana.com/docs/grafana/latest/installation/configure-docker/
@@ -69,7 +69,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
     ports:
       - 3001:3000
-    restart: unless-stopped
+    restart: always
 
   # https://github.com/prometheus/alertmanager
   # https://prometheus.io/docs/alerting/latest/overview/
@@ -91,7 +91,7 @@ services:
       - --web.external-url=http://${PAVICS_FQDN}:9093/
     ports:
       - 9093:9093
-    restart: unless-stopped
+    restart: always
 
 volumes:
   prometheus_persistence:

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -102,6 +102,8 @@ c.Authenticator.refresh_pre_spawn = True
 ## Blacklist of usernames that are not allowed to log in.
 # https://jupyterhub.readthedocs.io/en/stable/api/auth.html
 #
-# For security reasons, block user with known hardcoded public password.
-c.Authenticator.blacklist = set(['authtest'])  # v0.9+
-c.Authenticator.blocked_users = set(['authtest'])  # v1.2+
+# For security reasons, block user with known hardcoded public password or
+# non real Jupyter users.
+blocked_users = set(['authtest', '${CATALOG_USERNAME}', 'anonymous'])
+c.Authenticator.blacklist = blocked_users  # v0.9+
+c.Authenticator.blocked_users = blocked_users  # v1.2+

--- a/birdhouse/scripts/bootstrap-instance-for-testsuite
+++ b/birdhouse/scripts/bootstrap-instance-for-testsuite
@@ -26,9 +26,5 @@ sleep 5
 # Create test user.
 $THIS_DIR/create-magpie-authtest-user
 
-echo "
-\$ curl --include --silent https://<PAVICS_FQDN>/canarie/node/service/stats | head
-
-Should return the HTTP response code 200 to confirm instance is ready to run
-the testsuite.
-"
+# Check if instance properly provisionned for testsuite.
+$THIS_DIR/check-instance-ready

--- a/birdhouse/scripts/check-instance-ready
+++ b/birdhouse/scripts/check-instance-ready
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Quick smoke test for PAVICS instance.
+#
+# This is absolutely not a comprehensive test.
+#
+# Stronger test if optional-components/canarie-api-full-monitoring is
+# also enabled.
+#
+
+THIS_FILE="`realpath "$0"`"
+THIS_DIR="`dirname "$THIS_FILE"`"
+COMPOSE_DIR="`dirname "$THIS_DIR"`"
+
+if [ -f "$COMPOSE_DIR/env.local" ]; then
+    # Get PAVICS_FQDN
+    . $COMPOSE_DIR/env.local
+fi
+
+set -x
+curl --include --silent https://$PAVICS_FQDN/canarie/node/service/stats | head
+
+set +x
+echo "
+The curl above should return the HTTP response code 200 to confirm instance is ready.
+"
+set -x
+
+HTTP_RESPONSE_CODE="`curl --write-out '%{http_code}' --output /dev/null --silent https://$PAVICS_FQDN/canarie/node/service/stats`"
+if [ $HTTP_RESPONSE_CODE -ne 200 ]; then
+    set +x
+    echo "
+HTTP response code received: $HTTP_RESPONSE_CODE (expected 200).
+
+Will sleep for about 1 minute and try again since the canarie-api refresh every minute.
+
+Will retry only once more and exit immediately.
+"
+set -x
+    sleep 65
+    curl --include --silent https://$PAVICS_FQDN/canarie/node/service/stats | head
+fi


### PR DESCRIPTION
monitoring: prevent losing stats when VM auto start from a power failure

check-instance-ready: new script to smoke test instance (use in `bootstrap-instance-for-testsuite` for our automation pipeline).

jupyter: add CATALOG_USERNAME and anonymous to blocked_users list for security
    
    They are not real Jupyter users and their password is known.
    
    See config/magpie/permissions.cfg.template that created those users.
    
    Tested:
    ```
    [W 2020-11-20 13:25:18.924 JupyterHub auth:487] User 'admin-catalog' blocked. Stop authentication
    [W 2020-11-20 13:25:18.924 JupyterHub base:752] Failed login for admin-catalog
    
    [W 2020-11-20 13:49:18.069 JupyterHub auth:487] User 'anonymous' blocked. Stop authentication
    [W 2020-11-20 13:49:18.070 JupyterHub base:752] Failed login for anonymous
    ```
