### PR TITLE
pavics-compose.sh: fix annoying postgres false error

### DIFF
--- a/birdhouse/config/postgres/postgres-setup.sh
+++ b/birdhouse/config/postgres/postgres-setup.sh
@@ -16,7 +16,7 @@ databases_to_create=(
 echo 'Waiting for postgres database connection'
 while ! pg_isready -h postgres -U ${POSTGRES_USER}; do sleep 1; done;
 
-databases=$(psql -h postgres -U ${POSTGRES_USER} -t -c 'SELECT datname FROM pg_database WHERE datistemplate = false;')
+databases=$(psql -h postgres -U ${POSTGRES_USER} -d ${POSTGRES_DB} -t -c 'SELECT datname FROM pg_database WHERE datistemplate = false;')
 
 for db_to_create in ${databases_to_create[*]}
 do
@@ -31,7 +31,7 @@ do
 
     if [ $exists == false ] ; then
         echo "Creating database $db_to_create"
-        psql -h postgres -U ${POSTGRES_USER} -c "CREATE DATABASE $db_to_create;"
+        psql -h postgres -U ${POSTGRES_USER} -d ${POSTGRES_DB} -c "CREATE DATABASE $db_to_create;"
     fi
 
 done


### PR DESCRIPTION
Before fix:

```sh
$ ./pavics-compose up -d

(...)

Restarting proxy ... done
Waiting for postgres database connection
postgres:5432 - accepting connections
psql: FATAL:  database "postgres-pavics" does not exist
```

After fix:

```sh
Restarting proxy ... done
Waiting for postgres database connection
postgres:5432 - accepting connections
```

Root cause:

This commit
https://github.com/Ouranosinc/PAVICS/commit/7ffc6317a280486261bed1240369b890a743f5a8

changed

```diff
birdhouse/config/postgres/credentials.env
@@ -1,3 +0,0 @@
POSTGRES_USER=pavics
POSTGRES_DB=pavics
POSTGRES_PASSWORD=qwerty
```

to

```diff
birdhouse/config/postgres/credentials.env.template
@@ -0,0 +1,3 @@
POSTGRES_USER=${POSTGRES_PAVICS_USERNAME}
POSTGRES_PASSWORD=${POSTGRES_PAVICS_PASSWORD}
POSTGRES_DB=pavics
```

and so `POSTGRES_USER` do not match `POSTGRES_DB` anymore.