### PR TITLE
Add ability to execute post actions for deploy-data script

### DIFF
--- a/birdhouse/deployment/deploy-data
+++ b/birdhouse/deployment/deploy-data
@@ -123,7 +123,6 @@ for GIT_REPO_URL in $GIT_REPO_URLS; do
     fi
 
     SRC_DIRS="`yq r -p v $CONFIG_YML deploy\[$REPO_NUM\].dir_maps\[*\].source_dir`"
-    ensure_not_empty "$SRC_DIRS"
     DIR_NUM=0
 
     for SRC_DIR in $SRC_DIRS; do
@@ -154,6 +153,22 @@ for GIT_REPO_URL in $GIT_REPO_URLS; do
                 $SRC_DIR_ABS_PATH/ $DEST_DIR
 
         DIR_NUM=`expr $DIR_NUM + 1`
+    done
+
+    POST_ACTIONS_LENGTH="`yq r $CONFIG_YML --length deploy\[$REPO_NUM\].post_actions`"
+    if [ -z "$POST_ACTIONS_LENGTH" ]; then
+        # post_action element do not exist
+        POST_ACTIONS_LENGTH=0
+    fi
+    POST_ACTIONS_LENGTH_FOR_SEQ="`expr $POST_ACTIONS_LENGTH - 1`"
+
+    # will not fire if deploy\[*\].post_actions do not exist or is empty
+    for POST_ACTION_NUM in `seq 0 $POST_ACTIONS_LENGTH_FOR_SEQ`; do
+        POST_ACTION="`yq r -p v $CONFIG_YML deploy\[$REPO_NUM\].post_actions\[$POST_ACTION_NUM\].action`"
+        ensure_not_empty "$POST_ACTION"
+
+        echo "executing post_action '$POST_ACTION'"
+        eval $POST_ACTION
     done
 
     REPO_NUM=`expr $REPO_NUM + 1`

--- a/birdhouse/deployment/deploy-data
+++ b/birdhouse/deployment/deploy-data
@@ -80,7 +80,9 @@ START_TIME="`date -Isecond`"
 echo "==========
 datadeploy START_TIME=$START_TIME"
 
-DOCKER_RUN_TAG="`echo "$START_TIME" | sed 's/:/_/g'`"
+# 2020-12-16T22:15:03+0000 -> 2020-12-16T22_15_03p0000
+# Allowed chars for container name: [a-zA-Z0-9][a-zA-Z0-9_.-]
+DOCKER_RUN_TAG="`echo "$START_TIME" | sed 's/:/_/g' | sed 's/+/p/g'`"
 
 set -x
 

--- a/birdhouse/deployment/deploy-data
+++ b/birdhouse/deployment/deploy-data
@@ -64,7 +64,7 @@ fi
 
 
 yq() {
-    docker run --rm --name deploy_data_yq -v $CONFIG_YML:$CONFIG_YML:ro $DEPLOY_DATA_YQ_IMAGE yq "$@"
+    docker run --rm --name deploy_data_yq_$DOCKER_RUN_TAG -v $CONFIG_YML:$CONFIG_YML:ro $DEPLOY_DATA_YQ_IMAGE yq "$@"
 }
 
 # Empty value could mean typo in the keys in the config file.
@@ -79,6 +79,8 @@ ensure_not_empty() {
 START_TIME="`date -Isecond`"
 echo "==========
 datadeploy START_TIME=$START_TIME"
+
+DOCKER_RUN_TAG="`echo "$START_TIME" | sed 's/:/_/g'`"
 
 set -x
 
@@ -141,7 +143,7 @@ for GIT_REPO_URL in $GIT_REPO_URLS; do
         mkdir -p "$DEST_DIR_PARENT"
 
         # Rsync with --checksum to only update file that changed.
-        docker run --rm --name deploy_data_rsync \
+        docker run --rm --name deploy_data_rsync_$DOCKER_RUN_TAG \
             --volume $SRC_DIR_ABS_PATH:$SRC_DIR_ABS_PATH:ro \
             --volume $DEST_DIR_PARENT:$DEST_DIR_PARENT:rw \
             --user $USER_ID:$GROUP_ID \

--- a/birdhouse/deployment/deploy-data.config.sample.yml
+++ b/birdhouse/deployment/deploy-data.config.sample.yml
@@ -35,7 +35,11 @@ deploy:
   # post_actions:
   # Current work dir is the checkout root.
   # - action: ENV_VAR=for_script ENV_VAR2=value2 script/inside/checkout arg1 arg2
-  # - action: ANY_DEPLOY_DATA_VAR=${ANY_DEPLOY_DATA_VAR} ENV_VAR2=value2 /abs/path/dest_dir/script arg1 arg2
+  # - action: >-
+  #     ANY_DEPLOY_DATA_VAR=${ANY_DEPLOY_DATA_VAR}
+  #     ENV_VAR2=value2
+  #     /abs/path/dest_dir/script
+  #     arg1 arg2
 
 - repo_url: https://github.com/Ouranosinc/jenkins-config
   branch: 0b1592a7102c95a1e5090877b0edfc7d192ce0e2
@@ -59,7 +63,12 @@ deploy:
     # sync only 2 sub-dirs and .rst files under source/
   - source_dir: docs/
     dest_dir: /tmp/deploy-data-test-deploy/pavics-sdi
-    rsync_extra_opts: --include=*/ --include=source/tutorials/** --include=source/processes/** --include=source/*.rst --exclude=*
+    rsync_extra_opts: >-
+      --include=*/
+      --include=source/tutorials/**
+      --include=source/processes/**
+      --include=source/*.rst
+      --exclude=*
     # sync only .yml files at the root of checkout
   - source_dir: .
     dest_dir: /tmp/deploy-data-test-deploy/pavics-sdi
@@ -75,7 +84,13 @@ deploy:
   # execute actions without rsync
   post_actions:
   - action: ENV_VAR=for_script ENV_VAR2=value2 sh-utils/echoargs --opt1 arg1 arg2
-  - action: REPO_NUM=${REPO_NUM} GIT_REPO_URL=${GIT_REPO_URL} ECHOARGS2=var2 sh-utils/echoargs --opt1 --opt2 arg1 arg2 arg3
+  - action: >-
+      REPO_NUM=${REPO_NUM}
+      GIT_REPO_URL=${GIT_REPO_URL}
+      ECHOARGS2=var2
+      sh-utils/echoargs
+      --opt1 --opt2 arg1
+      arg2 arg3
   # show execution result of this sample config file
   - action: /bin/ls -l /tmp/deploy-data-clone-cache
   - action: find /tmp/deploy-data-test-deploy

--- a/birdhouse/deployment/deploy-data.config.sample.yml
+++ b/birdhouse/deployment/deploy-data.config.sample.yml
@@ -76,6 +76,9 @@ deploy:
   post_actions:
   - action: ENV_VAR=for_script ENV_VAR2=value2 sh-utils/echoargs --opt1 arg1 arg2
   - action: ECHOARG1=var1 ECHOARGS2=var2 sh-utils/echoargs --opt1 --opt2 arg1 arg2 arg3
+  # show execution result of this sample config file
+  - action: /bin/ls -l /tmp/deploy-data-clone-cache
+  - action: find /tmp/deploy-data-test-deploy
 
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/deployment/deploy-data.config.sample.yml
+++ b/birdhouse/deployment/deploy-data.config.sample.yml
@@ -35,7 +35,7 @@ deploy:
   # post_actions:
   # Current work dir is the checkout root.
   # - action: ENV_VAR=for_script ENV_VAR2=value2 script/inside/checkout arg1 arg2
-  # - action: ENV_VAR=for_script ENV_VAR2=value2 /abs/path/dest_dir/script arg1 arg2
+  # - action: ANY_DEPLOY_DATA_VAR=${ANY_DEPLOY_DATA_VAR} ENV_VAR2=value2 /abs/path/dest_dir/script arg1 arg2
 
 - repo_url: https://github.com/Ouranosinc/jenkins-config
   branch: 0b1592a7102c95a1e5090877b0edfc7d192ce0e2
@@ -75,7 +75,7 @@ deploy:
   # execute actions without rsync
   post_actions:
   - action: ENV_VAR=for_script ENV_VAR2=value2 sh-utils/echoargs --opt1 arg1 arg2
-  - action: ECHOARG1=var1 ECHOARGS2=var2 sh-utils/echoargs --opt1 --opt2 arg1 arg2 arg3
+  - action: REPO_NUM=${REPO_NUM} GIT_REPO_URL=${GIT_REPO_URL} ECHOARGS2=var2 sh-utils/echoargs --opt1 --opt2 arg1 arg2 arg3
   # show execution result of this sample config file
   - action: /bin/ls -l /tmp/deploy-data-clone-cache
   - action: find /tmp/deploy-data-test-deploy

--- a/birdhouse/deployment/deploy-data.config.sample.yml
+++ b/birdhouse/deployment/deploy-data.config.sample.yml
@@ -22,12 +22,20 @@ deploy:
   # optional, default "origin/master"
   # branch:
   checkout_name: jenkins-master
+  # dir_maps, optional: no rsync if missing
   dir_maps:
   # rsync content below source_dir into dest_dir
   - source_dir: initial-jenkins-plugins-suggestion
     dest_dir: /tmp/deploy-data-test-deploy/jenkins-plugins
     # optional, useful for include/exclude filter rules
     # rsync_extra_opts:
+  # post_action, optional, useful for:
+  # * post rsync additional file remapping
+  # * execute actions after clone, without rsync required
+  # post_actions:
+  # Current work dir is the checkout root.
+  # - action: ENV_VAR=for_script ENV_VAR2=value2 script/inside/checkout arg1 arg2
+  # - action: ENV_VAR=for_script ENV_VAR2=value2 /abs/path/dest_dir/script arg1 arg2
 
 - repo_url: https://github.com/Ouranosinc/jenkins-config
   branch: origin/master
@@ -60,3 +68,14 @@ deploy:
   - source_dir: docs/source
     dest_dir: /tmp/deploy-data-test-deploy/pavics-sdi
     rsync_extra_opts: --include=*/ --include=notebooks/** --exclude=*
+
+- repo_url: https://gitlab.com/tlvu/debug-utils
+  branch: origin/master
+  checkout_name: debug-utils
+  # execute actions without rsync
+  post_actions:
+  - action: ENV_VAR=for_script ENV_VAR2=value2 sh-utils/echoargs --opt1 arg1 arg2
+  - action: ECHOARG1=var1 ECHOARGS2=var2 sh-utils/echoargs --opt1 --opt2 arg1 arg2 arg3
+
+
+# vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/deployment/deploy-data.config.sample.yml
+++ b/birdhouse/deployment/deploy-data.config.sample.yml
@@ -19,7 +19,7 @@ config:
 deploy:
   # this form if clone over ssh: git@github.com:Ouranosinc/jenkins-master.git
 - repo_url: https://github.com/Ouranosinc/jenkins-master
-  # optional, default "origin/master"
+  # optional, default "origin/master" (f546be3017dba3717d787c9f7cd64342bd62e730)
   # branch:
   checkout_name: jenkins-master
   # dir_maps, optional: no rsync if missing
@@ -38,7 +38,7 @@ deploy:
   # - action: ENV_VAR=for_script ENV_VAR2=value2 /abs/path/dest_dir/script arg1 arg2
 
 - repo_url: https://github.com/Ouranosinc/jenkins-config
-  branch: origin/master
+  branch: 0b1592a7102c95a1e5090877b0edfc7d192ce0e2
   checkout_name: jenkins-config
   dir_maps:
   - source_dir: canarie-presentation/
@@ -53,7 +53,7 @@ deploy:
     rsync_extra_opts:
 
 - repo_url: https://github.com/Ouranosinc/pavics-sdi
-  # branch:
+  branch: ebf2e3f584ae424de3b01e4f320a91d8f766ec03
   checkout_name: pavics-sdi
   dir_maps:
     # sync only 2 sub-dirs and .rst files under source/
@@ -70,7 +70,7 @@ deploy:
     rsync_extra_opts: --include=*/ --include=notebooks/** --exclude=*
 
 - repo_url: https://gitlab.com/tlvu/debug-utils
-  branch: origin/master
+  branch: 2fad34e0daaf1532e38077fb11af7a84eb3978ab
   checkout_name: debug-utils
   # execute actions without rsync
   post_actions:


### PR DESCRIPTION
Script `deploy-data` was previously introduced in PR https://github.com/bird-house/birdhouse-deploy/pull/72 to deploy any files from any git repos to the local host it runs.

Now it grows the ability to run commands from the git repo it just pulls.

Being able to run commands open new possibilities:
* post-processing after files from git repo are deployed (ex: advanced file re-mapping)
* execute up-to-date scripts from git repos (PR https://github.com/bird-house/birdhouse-deploy-ouranos/pull/2)

Combining this `deploy-data` with the `scheduler` component means we have a way for cronjobs to automatically always execute the most up-to-date version of any scripts from any git repos.

@tlogan2000, @huard FYI this was required for the GEPS forecasts project.