### PR TITLE
deploy raven testdata to thredds: switch to new repo raven-testdata

### DIFF
--- a/birdhouse/deployment/deploy-data-raven-testdata-to-thredds.yml
+++ b/birdhouse/deployment/deploy-data-raven-testdata-to-thredds.yml
@@ -1,12 +1,12 @@
 deploy:
 #- repo_url: git@github.com:Ouranosinc/raven.git
-- repo_url: https://github.com/Ouranosinc/raven
+- repo_url: https://github.com/Ouranosinc/raven-testdata
   # optional, default "origin/master"
   # branch:
-  checkout_name: raven
+  checkout_name: raven-testdata
   dir_maps:
   # rsync content below source_dir into dest_dir
-  - source_dir: tests/testdata
+  - source_dir: .
     dest_dir: /data/datasets/testdata/raven
     # only sync .nc files
     rsync_extra_opts: --include=*/ --include=*.nc --exclude=*


### PR DESCRIPTION
For automated raven testdata sync at https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/testdata/raven/catalog.html

Will add the following new files from raven-testdata repo.  All existing are still there.
```
cd+++++++++ eccc_forecasts/                                                                                                                           
>f+++++++++ eccc_forecasts/geps_watershed.nc                                                                                                          
cd+++++++++ era5/                                               
>f+++++++++ era5/tas_pr_20180101-20180108.nc                                               
cd+++++++++ raven-routing-sample/                                                   
>f+++++++++ raven-routing-sample/VIC_streaminputs.nc
>f+++++++++ raven-routing-sample/era5-test-dataset-crop.nc
```

Part of issue https://github.com/Ouranosinc/raven/pull/324#pullrequestreview-540983876