### PR TITLE
jupyter: update to version 201214

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:201111"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:201214"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.5.3"
 


### PR DESCRIPTION
Matching PR to deploy the new Jupyter env in PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/56 to PAVICS.

Relevant changes:

```diff
>   - cfgrib=0.9.8.5=pyhd8ed1ab_0

<   - clisops=0.3.1=pyh32f6830_1
>   - clisops=0.4.0=pyhd3deb0d_0

<   - dask=2.30.0=py_0
>   - dask=2020.12.0=pyhd8ed1ab_0

<   - owslib=0.20.0=py_0
>   - owslib=0.21.0=pyhd8ed1ab_0

<   - xarray=0.16.1=py_0
>   - xarray=0.16.2=pyhd8ed1ab_0

<   - xclim=0.21.0=py_0
>   - xclim=0.22.0=pyhd8ed1ab_0

<   - jupyter_conda=3.4.1=pyh9f0ad1d_0
>   - jupyter_conda=4.1.0=hd8ed1ab_1
```

