### PR TITLE
bootstrap-testdata: add more for Raven

### DIFF
--- a/birdhouse/scripts/bootstrap-testdata
+++ b/birdhouse/scripts/bootstrap-testdata
@@ -20,6 +20,7 @@ testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r1i1p1_200601-200612.nc
 testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc
 testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc
 testdata/ta_Amon_MRI-CGCM3_decadal1980_r1i1p1_199101-200012.nc
+ets/Watersheds_5797_cfcompliant.nc
 "
 
 cd "$DATASET_ROOT"


### PR DESCRIPTION
For `docs/source/notebooks/canopex.ipynb` in commit
https://github.com/Ouranosinc/raven/commit/e50d3f3a969aff2f250538f4778aca57740d35e9

File has been renamed to https://github.com/Ouranosinc/raven/blob/766a288d282b99f097d0d2e0e4a31adf25b8d72c/docs/source/notebooks/Running_HMETS_with_CANOPEX_dataset.ipynb

See matching PR https://github.com/Ouranosinc/raven/pull/338