### PR TITLE
proxy: increase timeout since raven can take lots of time to process requests

### DIFF
--- a/birdhouse/README.rst
+++ b/birdhouse/README.rst
@@ -6,20 +6,15 @@ Docker instructions
 
 Requirements:
 
+* Centos 7 or Ubuntu Bionic (18.04), other distros untested.
 
-* 
-  Centos 7 or Ubuntu Bionic (18.04), other distros untested.
-
-* 
-  Hostname of Docker host must exist on the network.  Must use bridge
+* Hostname of Docker host must exist on the network.  Must use bridge
   networking if Docker host is a Virtual Machine.
 
-* 
-  User running ``pavics-compose.sh`` below must not be ``root`` but a regular user
+* User running ``pavics-compose.sh`` below must not be ``root`` but a regular user
   belonging to the ``docker`` group.
 
-* 
-  Install latest docker-ce and docker-compose for the chosen distro (not the
+* Install latest docker-ce and docker-compose for the chosen distro (not the
   version from the distro).
 
 To run ``docker-compose`` for PAVICS, the `pavics-compose.sh <pavics-compose.sh>`_ (:download:`download </birdhouse/pavics-compose.sh>`) wrapper script must be used.
@@ -85,25 +80,18 @@ Manual steps post deployment
 Change geoserver default admin password
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
-* 
-  Go to
+* Go to
   ``https://<PAVICS_FQDN>/geoserver/web/wicket/bookmarkable/org.geoserver.security.web.UserGroupRoleServicesPage`` (Security -> Users, Groups, and Roles)
 
-* 
-  Login using the default username ``admin`` and default password ``geoserver``.
+* Login using the default username ``admin`` and default password ``geoserver``.
 
-* 
-  Click on tab "Users/Groups".
+* Click on tab "Users/Groups".
 
-* 
-  Click on user "admin".
+* Click on user "admin".
 
-* 
-  Change the password.
+* Change the password.
 
-* 
-  Click "Save".
+* Click "Save".
 
 Create public demo user in Magpie for JupyterHub login
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,23 +111,19 @@ instructions below.
 
 Manual instructions:
 
-* 
-  Go to
+* Go to
   ``https://<PAVICS_FQDN>/magpie/ui/login`` and login with the ``admin`` user. The password should be in ``env.local``.
 
-* 
-  Then go to ``https://<PAVICS_FQDN>/magpie/ui/users/add``.
+* Then go to ``https://<PAVICS_FQDN>/magpie/ui/users/add``.
 
-* 
-  Fill in:
+* Fill in:
 
   * User name: <value of JUPYTER_DEMO_USER in ``env.local``\ >
   * Email: < anything is fine >
   * Password: < you decide >
   * User group: ``anonymous``
 
-* 
-  Click "Add User".
+* Click "Add User".
 
 Optional: prepare instance to run automated end-to-end test suite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,6 +149,7 @@ The canarie monitoring link
 ``https://<PAVICS_FQDN>/canarie/node/service/stats`` can be used to confirm the
 instance is ready to run the automated end-to-end test suite.  That link should
 return the HTTP response code ``200``.
+
 
 Vagrant instructions
 --------------------
@@ -227,6 +212,7 @@ Starting and managing the lifecycle of the VM:
    # not needed normally during tight development loop
    vagrant provision
 
+
 Tagging policy
 --------------
 
@@ -239,20 +225,17 @@ together.  So we need a slight modification to the definition of the standard.
 Given a version number MAJOR.MINOR.PATCH, increment the:
 
 
-#. 
-   MAJOR version when the API or user facing UI changes that requires
+#. MAJOR version when the API or user facing UI changes that requires
    significant documentation update and/or re-training of the users.  Also
    valid when a big milestone has been reached (ex: DACCS is released).
 
-#. 
-   MINOR version when we add new components or update existing components
+#. MINOR version when we add new components or update existing components
    that also require change to other existing components (ex: new Magpie that
    also force Twitcher and/or Frontend update) or the change to the existing
    component is a major one (ex: major refactoring of Twitcher, big merge
    with corresponding upstream component from birdhouse project).
 
-#. 
-   PATCH version when we update existing components without impact on other
+#. PATCH version when we update existing components without impact on other
    existing components and the change is a minor change for the existing
    component.
 

--- a/birdhouse/README.rst
+++ b/birdhouse/README.rst
@@ -1,3 +1,6 @@
+.. contents::
+
+
 Docker instructions
 -------------------
 

--- a/birdhouse/README.rst
+++ b/birdhouse/README.rst
@@ -67,6 +67,15 @@ To launch all the containers, use the following command:
 If you get a ``'No applicable error code, please check error log'`` error from the WPS processes, please make sure that the WPS databases exists in the
 postgres instance. See `create-wps-pgsql-databases.sh <scripts/create-wps-pgsql-databases.sh>`_ (:download:`download </birdhouse/scripts/create-wps-pgsql-databases.sh>`).
 
+
+Note
+----
+
+* All WPS requests should be completed within ``proxy_read_timeout`` of the
+  Nginx proxy, see `nginx.conf`_ (:download:`download <birdhouse/config/proxy/nginx.conf>`).
+  Any WPS requests that will take longer should use the async mode.
+
+
 Manual steps post deployment
 ----------------------------
 
@@ -243,3 +252,6 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
    PATCH version when we update existing components without impact on other
    existing components and the change is a minor change for the existing
    component.
+
+
+.. _nginx.conf: ./config/proxy/nginx.conf

--- a/birdhouse/config/proxy/nginx.conf
+++ b/birdhouse/config/proxy/nginx.conf
@@ -31,7 +31,7 @@ http {
     client_body_timeout 600s;
 
     # timeout for reading a response from the proxied server
-    proxy_read_timeout 120s;  # default 60s
+    proxy_read_timeout 240s;  # default 60s
 
     include /etc/nginx/conf.d/*.conf;
 


### PR DESCRIPTION
Fix this timeout error in some Raven notebooks:
```
HTTPError: 504 Server Error: Gateway Time-out for url:
https://pavics.ouranos.ca/twitcher/ows/proxy/raven/wps
```

This is just a work-around since something is very wrong on our
production host Boreas (a physical host with 128G ram and 48 logical cpu).

During the test, Boreas was having this "load average: 6.35, 5.90,
4.33".  For its hardware specs, it is basically idle.

The increased timeout was not needed for my test VM (10G ram, 2 cpu),
medus.ouranos.ca (physical host with 16G ram, 16 logical cpu) and
hirondelle.crim.ca (VM with 32G ram, 8 cpu).

Should fix https://github.com/Ouranosinc/raven/issues/362 and fix https://github.com/Ouranosinc/raven/issues/357.

Ping @moulab88 to take a look at Boreas.  Just a wild guess, is it due for a reboot?

Ping @richardarsenault can you retry the 2 broken Raven notebooks?  I've already deployed this to prod.