### PR TITLE
cronjob: attempt LetsEncrypt SSL renewal weekly instead of daily

### DIFF
--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -5,7 +5,8 @@
 
 # Cronjob schedule to trigger renew attempt.
 if [ -z "$RENEW_LETSENCRYPT_SSL_SCHEDULE" ]; then
-    RENEW_LETSENCRYPT_SSL_SCHEDULE="22 5 * * *"  # UTC
+    # Every Sunday morning 5:22 AM UTC time.
+    RENEW_LETSENCRYPT_SSL_SCHEDULE="22 5 * * 0"  # UTC
 fi
 
 # Number of parents above this repo to volume-mount.


### PR DESCRIPTION
To avoid cutting connection daily since the proxy is restarted during renewal attempt.