### PR TITLE
jupyter: update to version 210216 for xESMF

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server image
-export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:210201.2"
+export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:210216"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.6.1"
 


### PR DESCRIPTION
Matching PR to deploy https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/61 to PAVICS.

For regridding notebook, see https://github.com/Ouranosinc/pavics-sdi/pull/201#issuecomment-778329309.

Noticeable changes:

```diff
>   - xesmf=0.5.2=pyhd8ed1ab_0

<   - owslib=0.21.0=pyhd8ed1ab_0
>   - owslib=0.23.0=pyhd8ed1ab_0

<   - cftime=1.3.1=py37h6323ea4_0
>   - cftime=1.4.1=py37h902c9e0_0

<   - dask=2021.1.1=pyhd8ed1ab_0
>   - dask=2021.2.0=pyhd8ed1ab_0

<   - rioxarray=0.1.1=pyhd8ed1ab_0
>   - rioxarray=0.2.0=pyhd8ed1ab_0
```