### PR TITLE
finch: update to 0.7.0

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -4,7 +4,7 @@
 # Jupyter single-user server image
 export DOCKER_NOTEBOOK_IMAGE="pavics/workflow-tests:210216"
 
-export FINCH_IMAGE="birdhouse/finch:version-0.6.1"
+export FINCH_IMAGE="birdhouse/finch:version-0.7.0"
 
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.15"
 


### PR DESCRIPTION
Require PR https://github.com/bird-house/birdhouse-deploy/pull/131 for extra testdata for the new regridding notebook.

Regridding notebook will also need to be adjusted for some output to pass Jenkins test suite, PR https://github.com/Ouranosinc/pavics-sdi/pull/206.

Nbval escape regex also needed for the regridding notebook, PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/63

See Finch changelog in PR https://github.com/bird-house/finch/pull/158

Passing Jenkins build http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/update-nbval-sanitize-config-for-pavics-sdi-regridding-notebook/10/console