### PR TITLE
Avoid docker pull since pull rate limit on dockerhub

### DIFF
--- a/birdhouse/deployment/certbotwrapper
+++ b/birdhouse/deployment/certbotwrapper
@@ -106,7 +106,7 @@ if [ ! -z "$FORCE_CERTBOT_E2E" ]; then
     cd $THIS_DIR/..
     docker run --rm --name copy_cert \
         -v "/etc/letsencrypt:/etc/letsencrypt" \
-        bash \
+        bash:5.1.4 \
         cat $CERTPATH/fullchain.pem $CERTPATH/privkey.pem > $TMP_SSL_CERT
     if [ -s "$TMP_SSL_CERT" ] && ! diff $SSL_CERTIFICATE $TMP_SSL_CERT && [ $RC -eq 0 ]; then
         # Only modify SSL_CERTIFICATE if there are real changes.

--- a/birdhouse/deployment/deploy.sh
+++ b/birdhouse/deployment/deploy.sh
@@ -186,7 +186,7 @@ docker run --rm --name deploy_README_ipynb \
     -v "$JUPYTERHUB_USER_DATA_DIR":/notebook_dir \
     -v $REPO_ROOT/docs/source/notebooks:/nb:ro \
     -u root \
-    bash \
+    bash:5.1.4 \
     bash -c "cp -v /nb/README.ipynb /notebook_dir/.; \
              chown root:root /notebook_dir/README.ipynb"
 

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -90,7 +90,6 @@ fi
 __EOF__
 chmod a+x $TMP_SCRIPT
 
-docker pull bash
 docker run --rm \
   --name deploy_tutorial_notebooks \
   -u root \
@@ -98,7 +97,7 @@ docker run --rm \
   -v $TMPDIR/$TUTORIAL_NOTEBOOKS_DIR:/$TUTORIAL_NOTEBOOKS_DIR:ro \
   -v "$JUPYTERHUB_USER_DATA_DIR":$NOTEBOOK_DIR_MNT:rw \
   --entrypoint /deploy-notebook \
-  bash
+  bash:5.1.4
 
 
 # vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/birdhouse/scripts/backup-datavolume.sh
+++ b/birdhouse/scripts/backup-datavolume.sh
@@ -9,7 +9,7 @@ docker run --rm \
   -u root \
   -v $BACKUP_OUT_DIR:/backups \
   -v $DATA_VOL_NAME:/data_vol_to_backup:ro \
-  bash \
+  bash:5.1.4 \
   tar czvf /backups/$DATA_VOL_NAME.tgz -C /data_vol_to_backup .
 
 # vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/birdhouse/scripts/backup-jupyterhub-notebooks.sh
+++ b/birdhouse/scripts/backup-jupyterhub-notebooks.sh
@@ -14,7 +14,7 @@ docker run --rm \
   -u root \
   -v "$BACKUP_OUT_DIR":/backups \
   -v "$JUPYTERHUB_USER_DATA_DIR":/data_vol_to_backup:ro \
-  bash \
+  bash:5.1.4 \
   tar czvf /backups/jupyterhub_user_data.tgz -C /data_vol_to_backup .
 
 # vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Pin bash tag so it is reproducible (previously it was more or less reproducible since we always ensure "latest" tag).

Avoid the following error:

```
+ docker pull bash
Using default tag: latest
Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```