### PR TITLE
doc LetsEncrypt SSL renew job should be sourced after SSL_CERTIFICATE in env.local

### DIFF
--- a/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
+++ b/birdhouse/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
@@ -2,6 +2,9 @@
 # Configuration vars, set in env.local before sourcing this file.
 # This job assume the "scheduler" component is enabled.
 #
+# This job will write to the value of SSL_CERTIFICATE in env.local so make sure
+# this job is sourced after the last definition of SSL_CERTIFICATE.
+#
 ## Sample way to override default configs here in env.local:
 #
 ## Set the variable to override.

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -157,6 +157,9 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # See the job for additional possible configurations.  The "scheduler"
 # component needs to be enabled for this pre-configured job to work.
 #
+# This job will write to the value of SSL_CERTIFICATE here so make sure this
+# job is sourced after the last definition of SSL_CERTIFICATE.
+#
 #if [ -f "/<absolute path>/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env" ]; then
 #  . /<absolute path>/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 #fi

--- a/birdhouse/vagrant-utils/configure-pavics.sh
+++ b/birdhouse/vagrant-utils/configure-pavics.sh
@@ -32,6 +32,9 @@ RENEW_LETSENCRYPT_SSL_NUM_PARENTS_MOUNT="/"
 
 # Only source if file exist.  Allow for config file to be backward-compat with
 # older version of the repo where the .env file do not exist yet.
+# Keep this sourcing of renew_letsencrypt_ssl_cert_extra_job.env after
+# latest definition of SSL_CERTIFICATE because it needs the valid value of
+# SSL_CERTIFICATE.
 if [ -f "$PWD/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env" ]; then
     . $PWD/components/scheduler/renew_letsencrypt_ssl_cert_extra_job.env
 fi


### PR DESCRIPTION
Found accidentally when manually harmonizing `env.local` produced by
Vagrant with the template `env.local.example`.

Vagrant automatic provisioning does the right thing to activate
`renew_letsencrypt_ssl_cert_extra_job.env` after the redefined
SSL_CERTIFICATE but if someone like me, manually re-order this, it
will break.

Fix the follow error, SSL_CERTIFICATE was set to /home/vagrant/certkey.pem.
```
+ '[' -s /tmp/tmp_certbotwrapper_ssl_cert.pem ]
+ diff /home/vagrant/certkey.pem /tmp/tmp_certbotwrapper_ssl_cert.pem
diff: can't stat '/home/vagrant/certkey.pem': No such file or directory
+ '[' 0 -eq 0 ]
+ cp -v /tmp/tmp_certbotwrapper_ssl_cert.pem /home/vagrant/certkey.pem
cp: can't create '/home/vagrant/certkey.pem': No such file or directory
```