### PR TITLE
reverted name of monitoring routes to original

### DIFF
--- a/birdhouse/config/canarie-api/docker_configuration.py.template
+++ b/birdhouse/config/canarie-api/docker_configuration.py.template
@@ -195,7 +195,7 @@ SERVICES = {
             'provenance': 'https://ouranosinc.github.io/pavics-sdi/provenance/index.html'
         },
         'monitoring': {
-            'TDS-WMS': {
+            'ncWMS': {
                 'request': {
                     'url': 'https://${PAVICS_FQDN_PUBLIC}${TWITCHER_PROTECTED_PATH}/thredds/wms/birdhouse/testdata/ta_Amon_MRI-CGCM3_decadal1980_r1i1p1_199101-200012.nc?service=WMS&version=1.3.0&request=GetCapabilities'
                 }
@@ -228,7 +228,7 @@ SERVICES = {
             'provenance': 'https://ouranosinc.github.io/pavics-sdi/provenance/index.html'
         },
         'monitoring': {
-            'Finch': {
+            'Flyingpigeon': {
                 'request': {
                      'url': 'https://${PAVICS_FQDN_PUBLIC}${TWITCHER_PROTECTED_PATH}/finch?service=WPS&version=1.0.0&request=GetCapabilities'
                 }


### PR DESCRIPTION
The Canarie API complains that `stats` are up but don't return the correct response. I assume it's because I changed the monitoring key to reflect the actual content. 