### PR TITLE
magpie 3.x + gunicorn bind

### DIFF
--- a/birdhouse/README.rst
+++ b/birdhouse/README.rst
@@ -140,13 +140,14 @@ For that test suite to pass, run the script
 `scripts/bootstrap-instance-for-testsuite <scripts/bootstrap-instance-for-testsuite>`_ (:download:`download </birdhouse/scripts/bootstrap-instance-for-testsuite>`)
 to prepare your new instance.  Further documentation inside the script.
 
-Optional component
+Optional components
 `all-public-access <./optional-components#give-public-access-to-all-resources-for-testing-purposes>`_
-also need to be enabled in ``env.local``.
+and `secure-thredds <./optional-components/#control-secured-access-to-resources-example>`_
+also need to be enabled in ``env.local`` using ``EXTRA_CONF_DIRS`` variable.
 
 ESGF login is also needed for
 https://github.com/Ouranosinc/pavics-sdi/blob/master/docs/source/notebooks/esgf-dap.ipynb
-part of test suite.  ESGF credentails can be given to Jenkins via
+part of test suite.  ESGF credentials can be given to Jenkins via
 https://github.com/Ouranosinc/jenkins-config/blob/aafaf6c33ea60faede2a32850604c07c901189e8/env.local.example#L11-L13
 
 The canarie monitoring link

--- a/birdhouse/config/magpie/magpie.ini.template
+++ b/birdhouse/config/magpie/magpie.ini.template
@@ -64,7 +64,7 @@ prefix = /magpie
 
 [server:main]
 use = egg:gunicorn#main
-host = localhost
+host = 0.0.0.0
 port=2001
 timeout=10
 workers=3

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -13,6 +13,9 @@ export FINCH_IMAGE="birdhouse/finch:version-0.7.4"
 
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.15"
 
+# Tag version that will be used to update Magpie API, Magpie CLI, and matching Twitcher with Magpie Adapter
+export MAGPIE_VERSION=3.12.0
+
 # Root directory under which all data persistence should be nested under
 export DATA_PERSIST_ROOT="/data"
 

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -310,7 +310,7 @@ services:
     logging: *default-logging
 
   magpie:
-    image: pavics/magpie:3.10.0
+    image: pavics/magpie:3.12.0
     container_name: magpie
     ports:
       - "2001:2001"
@@ -338,7 +338,7 @@ services:
     logging: *default-logging
 
   twitcher:
-    image: pavics/twitcher:magpie-3.10.0
+    image: pavics/twitcher:magpie-3.12.0
     container_name: twitcher
     ports:
       - "8000:8000"

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -310,7 +310,7 @@ services:
     logging: *default-logging
 
   magpie:
-    image: pavics/magpie:3.8.0
+    image: pavics/magpie:3.10.0
     container_name: magpie
     ports:
       - "2001:2001"
@@ -338,7 +338,7 @@ services:
     logging: *default-logging
 
   twitcher:
-    image: pavics/twitcher:magpie-3.8.0
+    image: pavics/twitcher:magpie-3.10.0
     container_name: twitcher
     ports:
       - "8000:8000"

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -310,7 +310,7 @@ services:
     logging: *default-logging
 
   magpie:
-    image: pavics/magpie:3.12.0
+    image: pavics/magpie:${MAGPIE_VERSION}
     container_name: magpie
     ports:
       - "2001:2001"
@@ -338,7 +338,7 @@ services:
     logging: *default-logging
 
   twitcher:
-    image: pavics/twitcher:magpie-3.12.0
+    image: pavics/twitcher:magpie-${MAGPIE_VERSION}
     container_name: twitcher
     ports:
       - "8000:8000"

--- a/birdhouse/optional-components/secure-thredds/secure-access-magpie-permission.cfg
+++ b/birdhouse/optional-components/secure-thredds/secure-access-magpie-permission.cfg
@@ -36,9 +36,12 @@ permissions:
     group: anonymous
     action: create
 
-  # following permissions provide access to 'secure' directory to any user that is member of 'thredds-secure' group
-  # this access will take priority over 'anonymous' group above that gets denied public access to 'secure' directory
-  # users that must be granted access to the data under 'secure' should be added to the group and will inherit access
+  # Following permissions provide access to 'secure' directory nested under 'thredds' service to any user that is member
+  # of 'thredds-secure-authtest-group'. This permission will take priority over 'anonymous' group above that gets denied
+  # public access to 'secure' directory. Users that must be granted access to data under 'secure' should be added
+  # to the group to inherit permissions.
+  # The group is created dynamically if it doesn't already exist. User 'authtest' from 'create-magpie-authtest-user'
+  # script when bootstrapping the instance for testing purpose.
 
   - service: thredds
     resource: /birdhouse/testdata/secure
@@ -47,7 +50,7 @@ permissions:
       name: browse
       access: allow
       scope: recursive
-    group: thredds-secure
+    group: thredds-secure-authtest-group
     action: create
 
   - service: thredds
@@ -57,7 +60,7 @@ permissions:
       name: read
       access: allow
       scope: recursive
-    group: thredds-secure
+    group: thredds-secure-authtest-group
     action: create
 
   - service: thredds
@@ -67,5 +70,5 @@ permissions:
       name: write
       access: allow
       scope: recursive
-    group: thredds-secure
+    group: thredds-secure-authtest-group
     action: create

--- a/birdhouse/optional-components/secure-thredds/secure-access-magpie-permission.cfg
+++ b/birdhouse/optional-components/secure-thredds/secure-access-magpie-permission.cfg
@@ -1,9 +1,3 @@
-users:
-  - username: authtest
-    password: authtest1234
-    email: authtest@example.com
-    group: anonymous
-
 permissions:
   # note:
   #   following permissions can be combined with others such as 'optional-components/all-public-access'
@@ -42,7 +36,10 @@ permissions:
     group: anonymous
     action: create
 
-  # preserve access for test-suite user
+  # following permissions provide access to 'secure' directory to any user that is member of 'thredds-secure' group
+  # this access will take priority over 'anonymous' group above that gets denied public access to 'secure' directory
+  # users that must be granted access to the data under 'secure' should be added to the group and will inherit access
+
   - service: thredds
     resource: /birdhouse/testdata/secure
     type: directory
@@ -50,7 +47,7 @@ permissions:
       name: browse
       access: allow
       scope: recursive
-    user: authtest
+    group: thredds-secure
     action: create
 
   - service: thredds
@@ -60,7 +57,7 @@ permissions:
       name: read
       access: allow
       scope: recursive
-    user: authtest
+    group: thredds-secure
     action: create
 
   - service: thredds
@@ -70,5 +67,5 @@ permissions:
       name: write
       access: allow
       scope: recursive
-    user: authtest
+    group: thredds-secure
     action: create

--- a/birdhouse/optional-components/secure-thredds/secure-access-magpie-permission.cfg
+++ b/birdhouse/optional-components/secure-thredds/secure-access-magpie-permission.cfg
@@ -1,3 +1,9 @@
+users:
+  - username: authtest
+    password: authtest1234
+    email: authtest@example.com
+    group: anonymous
+
 permissions:
   # note:
   #   following permissions can be combined with others such as 'optional-components/all-public-access'

--- a/birdhouse/scripts/create-magpie-authtest-user
+++ b/birdhouse/scripts/create-magpie-authtest-user
@@ -10,7 +10,7 @@ THIS_DIR="`dirname "$THIS_FILE"`"
 
 TMP_CONFIG_FILE="/tmp/create-magpie-authtest-user.yml"
 
-# Test user is added to 'thredds-secure' group to obtain access to 'secure' directory under 'thredds' service.
+# Test user is added to 'thredds-secure-authtest-group' to obtain access to 'secure' directory under 'thredds' service.
 # Those permissions are defined in 'optional-components/secure-thredds/secure-access-magpie-permission.cfg'
 # which should also be included in 'EXTRA_CONF_DIRS' of your custom 'env.local' file.
 # This user is also automatically added to 'anonymous' group without the need of explicit membership here.
@@ -19,7 +19,7 @@ users:
    - username: authtest
      password: authtest1234
      email: authtest@example.com
-     group: thredds-secure
+     group: thredds-secure-authtest-group
 __OEF__
 
 set -x

--- a/birdhouse/scripts/create-magpie-authtest-user
+++ b/birdhouse/scripts/create-magpie-authtest-user
@@ -10,12 +10,16 @@ THIS_DIR="`dirname "$THIS_FILE"`"
 
 TMP_CONFIG_FILE="/tmp/create-magpie-authtest-user.yml"
 
+# Test user is added to 'thredds-secure' group to obtain access to 'secure' directory under 'thredds' service.
+# Those permissions are defined in 'optional-components/secure-thredds/secure-access-magpie-permission.cfg'
+# which should also be included in 'EXTRA_CONF_DIRS' of your custom 'env.local' file.
+# This user is also automatically added to 'anonymous' group without the need of explicit membership here.
 cat <<__OEF__ > $TMP_CONFIG_FILE
 users:
    - username: authtest
      password: authtest1234
      email: authtest@example.com
-     group: anonymous
+     group: thredds-secure
 __OEF__
 
 set -x

--- a/birdhouse/scripts/create-magpie-users
+++ b/birdhouse/scripts/create-magpie-users
@@ -69,6 +69,9 @@ THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
 COMPOSE_DIR="`dirname "$THIS_DIR"`"
 
+# must retrieve MAGPIE_VERSION
+. "${COMPOSE_DIR}/default.env"
+
 if [ -f "$COMPOSE_DIR/env.local" ]; then
     # Get PAVICS_FQDN, MAGPIE_ADMIN_PASSWORD, MAGPIE_ADMIN_USERNAME
     . $COMPOSE_DIR/env.local
@@ -98,7 +101,7 @@ if [ -z "$MAGPIE_CLI_CONF" ]; then
 fi
 
 if [ -z "$MAGPIE_CLI_IMAGE" ]; then
-    MAGPIE_CLI_IMAGE="pavics/magpie:3.12.0"
+    MAGPIE_CLI_IMAGE="pavics/magpie:${MAGPIE_VERSION}"
 fi
 
 # End configurable config via env var.

--- a/birdhouse/scripts/create-magpie-users
+++ b/birdhouse/scripts/create-magpie-users
@@ -65,16 +65,21 @@
 # bogus03      bvNWVWCQi8M6     409 : User name matches an already existing user name.
 #
 
+RED=$(tput setaf 1)
+NORMAL=$(tput sgr0)
+
 THIS_FILE="`realpath "$0"`"
 THIS_DIR="`dirname "$THIS_FILE"`"
 COMPOSE_DIR="`dirname "$THIS_DIR"`"
 
-# must retrieve MAGPIE_VERSION
-. "${COMPOSE_DIR}/default.env"
+# must retrieve MAGPIE_VERSION from 'default.env' or 'env.local'
+if [ -f "$COMPOSE_DIR/default.env" ]; then
+    . "${COMPOSE_DIR}/default.env"
+fi
 
 if [ -f "$COMPOSE_DIR/env.local" ]; then
     # Get PAVICS_FQDN, MAGPIE_ADMIN_PASSWORD, MAGPIE_ADMIN_USERNAME
-    . $COMPOSE_DIR/env.local
+    . "${COMPOSE_DIR}/env.local"
 fi
 
 ##############################################################################
@@ -101,6 +106,11 @@ if [ -z "$MAGPIE_CLI_CONF" ]; then
 fi
 
 if [ -z "$MAGPIE_CLI_IMAGE" ]; then
+    # MAGPIE_VERSION must be provided by 'default.env', 'env.local' or directly
+    if [ -z "${MAGPIE_VERSION}" ]; then
+        echo "${RED}Error${NORMAL}: Required MAGPIE_VERSION is undefined or empty."
+        exit 1
+    fi
     MAGPIE_CLI_IMAGE="pavics/magpie:${MAGPIE_VERSION}"
 fi
 

--- a/birdhouse/scripts/create-magpie-users
+++ b/birdhouse/scripts/create-magpie-users
@@ -98,7 +98,7 @@ if [ -z "$MAGPIE_CLI_CONF" ]; then
 fi
 
 if [ -z "$MAGPIE_CLI_IMAGE" ]; then
-    MAGPIE_CLI_IMAGE="pavics/magpie:3.8.0"
+    MAGPIE_CLI_IMAGE="pavics/magpie:3.12.0"
 fi
 
 # End configurable config via env var.


### PR DESCRIPTION
~should be tested after #151 for iterative updates~
Update directly to latest Magpie (3.8 -> ... -> 3.12)

Updates magpie 3.12 (see [CHANGES](https://github.com/Ouranosinc/Magpie/blob/master/CHANGES.rst#3120-2021-05-11) for details)

Changes: 
- Applies relevant modifications to configuration following `gunicorn` update in Magpie
  (docker image uses `pserve` CLI instead of directly calling `gunicorn`, which requires a small adjustment of `host`/`bind` value in the [magpie.ini](https://github.com/bird-house/birdhouse-deploy/blob/master/birdhouse/config/magpie/magpie.ini.template) config)
- Provides improved webhook configuration and implementations (for eventual [cowbird](https://github.com/Ouranosinc/cowbird))
- Providers headers `WWW-Authenticate` and `Location-When-Unauthenticated` when HTTP Unauthorized [401] is returned, which can help browsers/clients/users find the authentication endpoint to obtain needed access to the targeted resource.
- Includes some accumulated bugfixes
- use a shared `MAGPIE_VERSION` variable from `default.env` to align Magpie API, Magpie CLI, and Twitcher Magpie Adapter references
- Replace `authtest` user permissions in `optional-components/secure-thredds/secure-access-magpie-permission.cfg` to instead use new `thredds-secure` group, which `authtest` user will be a member of (resolves user-creation vs permission creation timing issues to make tests pass)