### PR TITLE
jupyter: update for new clisops, xclim, ravenpy

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210216"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210216-update210408"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.7.1"
 

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210216-update210408"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210408"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.7.1"
 


### PR DESCRIPTION
Matching PR to deploy the new Jupyter env to PAVICS.

See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/68
for more info.

Relevant changes:
```diff
<   - clisops=0.5.1=pyhd3deb0d_0
>   - clisops=0.6.3=pyh44b312d_0

<   - xclim=0.23.0=pyhd8ed1ab_0
>   - xclim=0.25.0=pyhd8ed1ab_0

>   - ostrich=0.1.2=h2bc3f7f_0
>   - raven=0.1.1=h2bc3f7f_0

<     - ravenpy==0.2.3  # from pip
>   - ravenpy=0.3.1=py37_0  # from conda

>   - aiohttp=3.7.4=py37h5e8e339_0

<   - roocs-utils=0.1.5=pyhd3deb0d_1
>   - roocs-utils=0.3.0=pyh6c4a22f_0

<   - cf_xarray=0.4.0=pyh44b312d_0
>   - cf_xarray=0.5.1=pyh44b312d_0

<   - rioxarray=0.2.0=pyhd8ed1ab_0
>   - rioxarray=0.3.1=pyhd8ed1ab_0

<   - xarray=0.16.2=pyhd8ed1ab_0
>   - xarray=0.17.0=pyhd8ed1ab_0

<   - geopandas=0.8.2=pyhd8ed1ab_0
>   - geopandas=0.9.0=pyhd8ed1ab_0

<   - gdal=3.1.4=py37h2ec2946_5
>   - gdal=3.2.1=py37hc5bc4e4_7

<   - jupyter_conda=4.1.0=hd8ed1ab_1
>   - jupyter_conda=5.0.0=hd8ed1ab_0

<   - python=3.7.9=hffdb5ce_100_cpython
>   - python=3.7.10=hffdb5ce_100_cpython
```
