### PR TITLE
testdata: new test file for new finch subset.ipynb

### DIFF
--- a/birdhouse/scripts/bootstrap-testdata
+++ b/birdhouse/scripts/bootstrap-testdata
@@ -24,6 +24,7 @@ ets/Watersheds_5797_cfcompliant.nc
 testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc
 cccma/CanESM2/historical/day/atmos/r1i1p1/tasmin/tasmin_day_CanESM2_historical_r1i1p1_18500101-20051231.nc
 cccma/CanESM2/historical/fx/atmos/r0i0p0/sftlf/sftlf_fx_CanESM2_historical_r0i0p0.nc
+testdata/xclim/NRCANdaily/nrcan_canada_daily_tasmin_1990.nc
 "
 
 cd "$DATASET_ROOT"


### PR DESCRIPTION
For notebook https://github.com/bird-house/finch/blob/e2298701dcd20b24dae021c666ebb684d3640b4b/docs/source/notebooks/subset.ipynb

To fix error in `docker logs finch`:
```
OSError: [Errno -102] NetCDF: Can't read file: b'https://lvupavicsdev.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/xclim/NRCANdaily$
nrcan_canada_daily_tasmin_1990.nc'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/envs/finch/lib/python3.9/site-packages/pywps/app/Process.py", line 248, in _run_process
    self.handler(wps_request, wps_response)  # the user must update the wps_response.
  File "/code/finch/processes/wps_base.py", line 42, in _handler_wrapper
    raise ProcessError(f"Finch failed with {err!r}")
pywps.app.exceptions.ProcessError: Finch failed with OSError -102, NetCDF: Can t read file
```

Together with https://github.com/bird-house/finch/pull/177 + latest Finch docker + latest xESMF, we have a working Jenkins build http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/minor-fixes-launchnotebook-nbval-lax-as-option/12/console