### PR TITLE
Update raven and jupyter env for raven demo

### DIFF
--- a/birdhouse/config/finch/wps.cfg.template
+++ b/birdhouse/config/finch/wps.cfg.template
@@ -2,6 +2,9 @@
 outputurl = https://${PAVICS_FQDN_PUBLIC}/wpsoutputs
 outputpath = /data/wpsoutputs
 
+# default 3mb, fix "Broken pipe" between the proxy and the wps service
+maxrequestsize = 100mb
+
 [logging]
 level = INFO
 database=postgresql://${POSTGRES_PAVICS_USERNAME}:${POSTGRES_PAVICS_PASSWORD}@postgres/finch

--- a/birdhouse/config/finch/wps.cfg.template
+++ b/birdhouse/config/finch/wps.cfg.template
@@ -5,6 +5,9 @@ outputpath = /data/wpsoutputs
 # default 3mb, fix "Broken pipe" between the proxy and the wps service
 maxrequestsize = 100mb
 
+# default 2, too low for a production server with capable CPUs
+parallelprocesses = 10
+
 [logging]
 level = INFO
 database=postgresql://${POSTGRES_PAVICS_USERNAME}:${POSTGRES_PAVICS_PASSWORD}@postgres/finch

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -92,6 +92,15 @@ c.JupyterHub.log_level = logging.DEBUG
 
 c.Spawner.debug = True
 
+## Timeout (in seconds) to wait for spawners to initialize
+c.JupyterHub.init_spawners_timeout = 20  # default 10
+
+## Timeout (in seconds) before giving up on a spawned HTTP server
+c.Spawner.http_timeout = 60  # default 30
+
+## Timeout (in seconds) before giving up on starting of single-user server.
+c.Spawner.start_timeout = 120  # default 60
+
 ## Extra arguments to be passed to the single-user server.
 c.Spawner.args = ["--NotebookApp.terminals_enabled=False"]
 

--- a/birdhouse/config/raven/wps.cfg.template
+++ b/birdhouse/config/raven/wps.cfg.template
@@ -2,6 +2,9 @@
 outputurl = https://${PAVICS_FQDN_PUBLIC}/wpsoutputs
 outputpath = /data/wpsoutputs
 
+# default 3mb, fix "Broken pipe" between the proxy and the wps service
+maxrequestsize = 100mb
+
 [logging]
 level = INFO
 database=postgresql://${POSTGRES_PAVICS_USERNAME}:${POSTGRES_PAVICS_PASSWORD}@postgres/raven

--- a/birdhouse/config/raven/wps.cfg.template
+++ b/birdhouse/config/raven/wps.cfg.template
@@ -5,6 +5,9 @@ outputpath = /data/wpsoutputs
 # default 3mb, fix "Broken pipe" between the proxy and the wps service
 maxrequestsize = 100mb
 
+# default 2, too low for a production server with capable CPUs
+parallelprocesses = 10
+
 [logging]
 level = INFO
 database=postgresql://${POSTGRES_PAVICS_USERNAME}:${POSTGRES_PAVICS_PASSWORD}@postgres/raven

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210414"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210414.1"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.7.3"
 

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210414.1"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210415"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.7.3"
 

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -172,7 +172,7 @@ services:
     restart: always
 
   raven:
-    image: pavics/raven:0.12.0
+    image: pavics/raven:0.12.1
     container_name: raven
     ports:
       - "8096:9099"

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -172,7 +172,7 @@ services:
     restart: always
 
   raven:
-    image: pavics/raven:0.11.1
+    image: pavics/raven:0.12.0
     container_name: raven
     ports:
       - "8096:9099"


### PR DESCRIPTION
Raven release notes PR https://github.com/Ouranosinc/raven/pull/374 + https://github.com/Ouranosinc/raven/pull/382

Jupyter env update PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/71

Other fixes:
* Fix intermittent Jupyter spawning error by doubling various timeouts config (it's intermittent so hard to test so we are not sure which ones of timeout fixed it)
* Fix Finch and Raven "Broken pipe" error when the request size is larger than default 3mb (bumped to 100mb) (fixes https://github.com/Ouranosinc/raven/issues/361 and Finch related comment https://github.com/bird-house/finch/issues/98#issuecomment-811230388)
* Lower chance to have "Max connection" error for Finch and Raven (bump parallelprocesses from 2 to 10). In prod, the server has the CPU needed to run 10 concurrent requests if needed so this prevent users having to "wait" after each other.