### PR TITLE
update magpie v3.9.0

### DIFF
--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -286,7 +286,7 @@ services:
     restart: always
 
   magpie:
-    image: pavics/magpie:3.8.0
+    image: pavics/magpie:3.9.0
     container_name: magpie
     ports:
       - "2001:2001"
@@ -313,7 +313,7 @@ services:
     restart: always
 
   twitcher:
-    image: pavics/twitcher:magpie-3.8.0
+    image: pavics/twitcher:magpie-3.9.0
     container_name: twitcher
     ports:
       - "8000:8000"


### PR DESCRIPTION
[CHANGES](https://github.com/Ouranosinc/Magpie/blob/master/CHANGES.rst#390-2021-04-06)

Provides multiple updates related to authentication headers metadata that can be used by browsers to locate the endpoint where to authenticate. 

