### PR TITLE
proxy: allow homepage (location /) to be configurable

### DIFF
--- a/birdhouse/config/proxy/conf.d/all-services.include.template
+++ b/birdhouse/config/proxy/conf.d/all-services.include.template
@@ -1,5 +1,5 @@
     location / {
-        return 302 https://$host/jupyter/hub/login;
+        ${PROXY_ROOT_LOCATION}
     }
 
     location /frontend/ {

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -55,3 +55,7 @@ export AUTODEPLOY_NOTEBOOK_FREQUENCY="@hourly"
 # Timeout for reading a response from the proxied server.
 # Any WPS processes taking longer than this should use async mode.
 export PROXY_READ_TIMEOUT_VALUE="240s"
+
+# Content of "location /" in file config/proxy/conf.d/all-services.include.template
+# Useful to have a custom homepage.
+export PROXY_ROOT_LOCATION="return 302 https://\$host/jupyter/hub/login;"

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -192,6 +192,13 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 #  . $COMPOSE_DIR/components/scheduler/deploy_data_job.env
 #fi
 
+# Content of "location /" in file config/proxy/conf.d/all-services.include.template
+# Useful to have a custom homepage.
+# Default:
+#export PROXY_ROOT_LOCATION="return 302 https://\$host/jupyter/hub/login;"
+# Sample, remember to add this /data/homepage volume mount to proxy container.
+#export PROXY_ROOT_LOCATION="alias /data/homepage/;"
+
 # Public (on the internet) fully qualified domain name of this Pavics
 # installation.  This is optional so default to the same internal PAVICS_FQDN if
 # not set.

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -197,6 +197,7 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # Default:
 #export PROXY_ROOT_LOCATION="return 302 https://\$host/jupyter/hub/login;"
 # Sample, remember to add this /data/homepage volume mount to proxy container.
+# See PR https://github.com/bird-house/birdhouse-deploy-ouranos/pull/11.
 #export PROXY_ROOT_LOCATION="alias /data/homepage/;"
 
 # Public (on the internet) fully qualified domain name of this Pavics

--- a/birdhouse/pavics-compose.sh
+++ b/birdhouse/pavics-compose.sh
@@ -48,6 +48,7 @@ OPTIONAL_VARS='
   $AUTODEPLOY_NOTEBOOK_FREQUENCY
   $AUTODEPLOY_EXTRA_SCHEDULER_JOBS
   $PROXY_READ_TIMEOUT_VALUE
+  $PROXY_ROOT_LOCATION
 '
 
 # we switch to the real directory of the script, so it still works when used from $PATH


### PR DESCRIPTION
For each org to have their own custom homepage.

Existing default to redirect to JupyterHub login page is preserved for when no custom homepage is required.

See matching PR for deploying Ouranos custom homepage https://github.com/bird-house/birdhouse-deploy-ouranos/pull/11.

Test server: https://lvupavics.ouranos.ca

Fixes https://github.com/Ouranosinc/PAVICS-landing/issues/20.

