### PR TITLE
 issue/PR templates & auto-labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,7 +3,7 @@ name: ":bug: Bug Report"
 about: Create an issue related to a bug or encountered problem.
 title: ":bug: [BUG]: "
 labels: bug
-assignees: tlvu, fmigneault
+assignees: tlvu, MatProv
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,48 @@
+---
+name: ":bug: Bug Report"
+about: Create an issue related to a bug or encountered problem.
+title: ":bug: [BUG]: "
+labels: bug
+assignees: tlvu, fmigneault
+
+---
+
+## Summary
+
+<!-- A simple TL;DR one/two-liner summary of your problem -->
+
+
+## Details
+
+<!-- A clear and concise description of what the bug is and what is expected otherwise. -->
+
+
+
+### To Reproduce
+
+Steps to reproduce the behavior:
+
+1.
+2.
+3.
+
+
+## Environment
+
+| Information           | Value
+| --------------------- | --------------------------------------------------------------
+| Server/Platform URL   | <!-- e.g: https://pavics.ouranos.ca -->
+| Version Tag/Commit    | <!-- 1.2.3 --> 
+| Related issues/PR     | <!-- #<issue> #<pr> -->
+| Related components    | <!-- thredds, magpie, monitoring, etc. -->
+| Custom configuration  | <!-- path to config or relevant test suite repo/branch -->
+
+
+## Concerned Organizations
+
+<!-- 
+  If you know some developers or platform maintainers directly impacted by this bug, 
+
+  @tag them below 
+-->
+

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,26 @@
+---
+name: ":books: Documentation"
+about: Report an issue related to missing, incorrect or insufficient documentation.
+title: ":books: [Documentation]: "
+labels: documentation
+assignees: tlvu
+---
+
+## Description
+
+<!-- Provide a description of the documentation issue. -->
+
+
+
+## References
+
+<!-- 
+  Additional screenshots or links to help identify the issue?
+-->
+
+
+| Information           | Value
+| --------------------- | --------------------------------------------------------------
+| Server/Platform URL   | <!-- Any applicable instance, e.g: https://pavics.ouranos.ca -->
+| Related issues/PR     | <!-- URL to any existing issues in https://github.com/Ouranosinc/pavics-sdi/issues ? -->
+| Related documentation | <!-- URL to incorrect https://ouranosinc.github.io/pavics-sdi/index.html HTML doc tag? -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -23,4 +23,4 @@ assignees: tlvu
 | --------------------- | --------------------------------------------------------------
 | Server/Platform URL   | <!-- Any applicable instance, e.g: https://pavics.ouranos.ca -->
 | Related issues/PR     | <!-- URL to any existing issues in https://github.com/Ouranosinc/pavics-sdi/issues ? -->
-| Related documentation | <!-- URL to incorrect https://ouranosinc.github.io/pavics-sdi/index.html HTML doc tag? -->
+| Related documentation | <!-- URL to incorrect https://pavics-sdi.readthedocs.io/ HTML doc tag? -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,36 @@
+---
+name: Feature Request
+about: Suggest an idea, new feature or enhancement to existing functionalities.
+title: ":bulb: [Feature]"
+labels: enhancement 
+assignees: tlvu
+
+---
+
+## Description
+
+<!-- 
+    Describe the requested feature. 
+
+    - What does the feature provide?
+    - What changes does it require? 
+-->
+
+
+
+## References
+
+<!-- 
+  Additional screenshots or links to help understand the request?
+-->
+
+
+## Concerned Organizations
+
+<!-- 
+  If you know some developers or platform maintainers directly impacted or
+  that should participate in the development of this feature
+
+  @tag them below
+-->
+

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -3,7 +3,7 @@ name: ":question: Question"
 about: Ask a question or request general help support.
 title: ":question: [Question]: "
 labels: question
-assignees: tlvu
+assignees: tlvu, MatProv
 ---
 
 ## Questions

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,30 @@
+---
+name: ":question: Question"
+about: Ask a question or request general help support.
+title: ":question: [Question]: "
+labels: question
+assignees: tlvu
+---
+
+## Questions
+
+
+<!-- Please provide your question details. -->
+
+
+
+## References
+
+<!-- 
+  Additional screenshots or links to help identify the issue?
+-->
+
+
+## Environment
+
+| Information           | Value
+| --------------------- | --------------------------------------------------------------
+| Server/Platform URL   | <!-- e.g: https://pavics.ouranos.ca -->
+| Version Tag/Commit    | <!-- 1.2.3 --> 
+| Related issues/PR     | <!-- #<issue> #<pr> -->
+| Related components    | <!-- thredds, magpie, monitoring, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
-# Overview
+## Overview
 
-Please include a summary of the changes and which issues are fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Please include a summary of the changes and which issues are fixed. 
 
-This PR fixes [issue id](url)
+Please also include relevant motivation and context. 
+
+List any dependencies that are required for this change.
 
 ## Changes
 
@@ -16,7 +18,7 @@ This PR fixes [issue id](url)
 
 ## Related Issue / Discussion
 
-- Resolves ...
+- Resolves [issue id](url)
 
 ## Additional Information
 

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,19 @@
+# label rules used by .github/workflows/label.yml
+
+# label 'ci' all automation-related steps and files
+#   Since this repository is in itself an automation process to deploy a server instance,
+#   we refer here to CI as the 'meta' configuration files for managing the code and integrations with the repository,
+#   not configurations related to the deployment process itself.
+ci:
+  - .*  # all '.<something>' files
+  - .github/**/*
+  - docs/Makefile
+  - Dockerfile*
+
+documentation:
+  - "*.rst"
+  - "*.example"
+  - ".readthedocs.yml"
+  - docs/**/*
+  - CONTRIBUTING.rst
+  - README.rst

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,19 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/first-interaction@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: >
+          Thanks for submitting an issue.
+
+          Please make sure to provide enough details for us to be able to replicate your issue or understand your question.
+        pr-message: >
+          Thanks for submitting a PR.
+
+          Make sure you have looked at [CONTRIBUTING](https://github.com/bird-house/birdhouse-deploy/blob/master/CONTRIBUTING.rst) guidelines.

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Overview

Improve CI templates and labelling of issues for the repo.

## Changes

**Non-breaking changes**
- Adds issue Github templates, for each of: documentation, (question) support, bug and feature request.
- Update formatting of existing PR template 
- Add auto-labeler action that will apply labels onto matched modified files by PRs. 
- Auto-label opened issues (with above templates) with corresponding labels.

**Breaking changes**
n/a

## Related Issue / Discussion

- Resolves #158 

## Additional Information

see auto-label already in action just below :arrow_down: 