### PR TITLE
bump default log retention to 500m instead of 2m, more suitable for prod

### DIFF
--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -4,7 +4,7 @@ x-logging:
   &default-logging
   driver: "json-file"
   options:
-    max-size: "200k"
+    max-size: "50m"
     max-file: "10"
 
 services:


### PR DESCRIPTION
# Overview

Bump default log retention to 500m instead of 2m, more suitable for prod

Forgot to push during PR https://github.com/bird-house/birdhouse-deploy/pull/152.

## Changes

**Non-breaking changes**
- Bump default log retention to 500m instead of 2m, more suitable for prod
