### PR TITLE
jupyterhub: update to ver 1.4.0-20210506

### DIFF
--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -371,7 +371,7 @@ services:
     logging: *default-logging
 
   jupyterhub:
-    image: pavics/jupyterhub:1.3.0-20201211
+    image: pavics/jupyterhub:1.4.0-20210506
     container_name: jupyterhub
     hostname: jupyterhub
     ports:


### PR DESCRIPTION
## Changes

**Non-breaking changes**

- jupyterhub: update to ver 1.4.0-20210506

## Tests

- Deployed to https://lvupavics.ouranos.ca/jupyter
- Able to login
- Able to start personal Jupyter server

## Additional Information

- Jupyter hub release note: https://github.com/jupyterhub/jupyterhub/blob/master/docs/source/changelog.md