### PR TITLE
Update to raven 0.13.0

### DIFF
--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -189,7 +189,7 @@ services:
     logging: *default-logging
 
   raven:
-    image: pavics/raven:0.12.1
+    image: pavics/raven:0.13.0
     container_name: raven
     ports:
       - "8096:9099"


### PR DESCRIPTION
This updates raven to 0.13.0, which corresponds to the work done in these PRs:

* https://github.com/Ouranosinc/raven/pull/384
* https://github.com/Ouranosinc/raven/pull/385
* https://github.com/Ouranosinc/raven/pull/386

This was needed following the upgrade to RavenPy 0.5
