### PR TITLE
Mapie/Twticher Cache Settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,19 @@
 
   - Update `Magpie` version to 3.14.0 with corresponding `Twitcher` using `MagpieAdapter` to obtain fixes about
     request caching and logging improvements during `Twitcher` security check failure following raised exception.
+    
+    Please note that because the previous default version was 3.12.0, a security fix introduced in 3.13.0 is included.
+    (see details here: [3.13.0 (2021-06-29)](https://github.com/Ouranosinc/Magpie/blob/master/CHANGES.rst#3130-2021-06-29))
+    
+    This security fix explicitly disallows duplicate emails for different user accounts, which might require manual 
+    database updates if such users exist on your server instance. To look for possible duplicates, the following command
+    can be used. Duplicate entries must be updated or removed such that only unique emails are present.
+    
+    ```shell
+    echo "select email,user_name from users" | \
+    docker exec -i postgres-magpie psql -U $POSTGRES_MAGPIE_USERNAME magpiedb | \
+    sort > /tmp/magpie_users.txt
+    ````
 
   ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,17 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+  ### Changes
+
+  - Add request caching settings in `TWitcher` INI configuration to work with `Magpie` to help reduce permission and
+    access control computation time.
+    
+  - Add `magpie` logger under `Twitcher` INI configuration to provide relevant logging details provided 
+    by `MagpieAdapter` it employs for service and resource access resolution.
+
+  - Change logging level of `sqlalchemy.engin` under `Magpie` INI configuration to `WARN` in order to avoid by default
+    over verbose database queries.
+
 
 [1.13.14](https://github.com/bird-house/birdhouse-deploy/tree/1.13.14) (2021-07-29)
 ------------------------------------------------------------------------------------------------------------------
@@ -131,7 +141,7 @@
 [1.13.11](https://github.com/bird-house/birdhouse-deploy/tree/1.13.11) (2021-07-06)
 ------------------------------------------------------------------------------------------------------------------
 
-  ###  Changes
+  ### Changes
 
   - Notebook deployment: allow to specify required branch for any tutorial
     notebook repos in `env.local`.
@@ -154,7 +164,7 @@
 [1.13.10](https://github.com/bird-house/birdhouse-deploy/tree/1.13.10) (2021-06-30)
 ------------------------------------------------------------------------------------------------------------------
 
-  ###  Changes
+  ### Changes
   
   - Add `bump2version` configuration to allow self-update of files that refer to new version releases 
     and apply update of features listed in this changelog.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
   - Add `magpie` logger under `Twitcher` INI configuration to provide relevant logging details provided 
     by `MagpieAdapter` it employs for service and resource access resolution.
 
-  - Change logging level of `sqlalchemy.engin` under `Magpie` INI configuration to `WARN` in order to avoid by default
+  - Change logging level of `sqlalchemy.engine` under `Magpie` INI configuration to `WARN` in order to avoid by default
     over verbose database queries.
 
   - Update `Magpie` version to 3.14.0 with corresponding `Twitcher` using `MagpieAdapter` to obtain fixes about

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,13 @@
   - Change logging level of `sqlalchemy.engin` under `Magpie` INI configuration to `WARN` in order to avoid by default
     over verbose database queries.
 
+  - Update `Magpie` version to 3.14.0 with corresponding `Twitcher` using `MagpieAdapter` to obtain fixes about
+    request caching and logging improvements during `Twitcher` security check failure following raised exception.
+
+  ### Fixes
+
+  - Adjust incorrect `magpie.url` value in `Magpie` INI configuration.
+
 
 [1.13.14](https://github.com/bird-house/birdhouse-deploy/tree/1.13.14) (2021-07-29)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,7 @@
     echo "select email,user_name from users" | \
     docker exec -i postgres-magpie psql -U $POSTGRES_MAGPIE_USERNAME magpiedb | \
     sort > /tmp/magpie_users.txt
-    ````
+    ```
 
   ### Fixes
 

--- a/birdhouse/config/magpie/magpie.ini.template
+++ b/birdhouse/config/magpie/magpie.ini.template
@@ -49,6 +49,24 @@ ziggurat_foundations.session_provider_callable = magpie.models:get_session_calla
 github.client_id=${GITHUB_CLIENT_ID}
 github.client_secret=${GITHUB_CLIENT_SECRET}
 
+# Caching settings for specific sections/functions - improves performance response times of recurring requests
+# See Twitcher INI configuration for caching that takes effect when resolving access enforcement to actual services.
+# Following cache settings apply only during Magpie API requests.
+#
+# NOTE: Caching will only take effect with Magpie >= 3.7
+# Detail:
+#   Region 'acl' takes effect whenever computing "effective permissions" of user/group onto a service/resource.
+#   Because Magpie is employed to manage those permissions and that computing the effective resolution of the
+#   complete resource hierarchy and full user-group membership inheritance is fairly rare, caching is not specifically
+#   needed here. It is actually more often then not useful to always refresh the latest states to be sure of which
+#   permissions are actually applied when the administrator manages them. Therefore, all caches are disabled here, but
+#   this is not the case on Twitcher side.
+cache.regions = acl, service
+cache.type = memory
+cache.enabled = false
+cache.acl.enabled = false
+cache.service.enabled = false
+
 [app:api_app]
 use = egg:Paste#static
 document_root = %(here)s/ui/swagger

--- a/birdhouse/config/magpie/magpie.ini.template
+++ b/birdhouse/config/magpie/magpie.ini.template
@@ -95,13 +95,19 @@ handlers = console
 formatter = generic
 
 [logger_magpie]
+# "level = DEBUG"   logs detailed information about operations/settings (not for production, will leak sensitive data)
+# "level = INFO"    reports useful information, not leaking details about settings
+# "level = WARN"    only potential problems are reported
 level = INFO
 handlers =
 qualname = magpie
 formatter = generic
 
 [logger_sqlalchemy]
-level = INFO
+# "level = DEBUG"   logs SQL queries, transactions and results
+# "level = INFO"    logs SQL queries (data can be identified from query field values)
+# "level = WARN"    logs neither (recommended for production systems, avoid anything below unless for dev/debug system)
+level = WARN
 handlers =
 qualname = sqlalchemy.engine
 formatter = generic

--- a/birdhouse/config/magpie/magpie.ini.template
+++ b/birdhouse/config/magpie/magpie.ini.template
@@ -28,7 +28,7 @@ pyramid.includes = pyramid_tm ziggurat_foundations.ext.pyramid.sign_in ziggurat_
 #   other overridable variables available in magpie/constants.py
 #
 magpie.port = 2001
-magpie.url = http://localhost:2001
+magpie.url = https://${$PAVICS_FQDN}/magpie
 magpie.max_restart = 5
 magpie.push_phoenix = true
 # This secret should be the same in Twitcher !

--- a/birdhouse/config/magpie/magpie.ini.template
+++ b/birdhouse/config/magpie/magpie.ini.template
@@ -28,7 +28,7 @@ pyramid.includes = pyramid_tm ziggurat_foundations.ext.pyramid.sign_in ziggurat_
 #   other overridable variables available in magpie/constants.py
 #
 magpie.port = 2001
-magpie.url = https://${$PAVICS_FQDN}/magpie
+magpie.url = https://${PAVICS_FQDN}/magpie
 magpie.max_restart = 5
 magpie.push_phoenix = true
 # This secret should be the same in Twitcher !

--- a/birdhouse/config/twitcher/twitcher.ini.template
+++ b/birdhouse/config/twitcher/twitcher.ini.template
@@ -22,9 +22,13 @@ sqlalchemy.url = sqlite:///%(here)s/twitcher.sqlite
 retry.attempts = 3
 
 # caching settings for specific sections/functions
-cache.regions = acl
+cache.regions = acl, service
 cache.type = memory
+cache.acl.enabled = true
 cache.acl.expire = 60
+# NOTE: following will only take effect with Magpie >= 3.7
+cache.service.enabled = true
+cache.service.expire = 20
 
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.

--- a/birdhouse/config/twitcher/twitcher.ini.template
+++ b/birdhouse/config/twitcher/twitcher.ini.template
@@ -21,6 +21,11 @@ sqlalchemy.url = sqlite:///%(here)s/twitcher.sqlite
 
 retry.attempts = 3
 
+# caching settings for specific sections/functions
+cache.regions = acl
+cache.type = memory
+cache.acl.expire = 60
+
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1

--- a/birdhouse/config/twitcher/twitcher.ini.template
+++ b/birdhouse/config/twitcher/twitcher.ini.template
@@ -22,8 +22,14 @@ sqlalchemy.url = sqlite:///%(here)s/twitcher.sqlite
 retry.attempts = 3
 
 # Caching settings for specific sections/functions - improves performance response times of recurring requests
-# Although related to Magpie, cache regions settings executed by 'MagpieAdapter' are running under Twitcher to
-# resolve Access Control Lists to services, and must therefore be placed in Twitcher configuration.
+# For caching related to Magpie API endpoints themselves, instead refer to Magpie INI configuration file.
+#
+#   Although related to Magpie code, cache regions settings executed by 'MagpieAdapter' are running under Twitcher
+#   to resolve Access Control Lists (ACL) to services/resources, and must therefore be placed in Twitcher configuration.
+#   Caching that takes effect in Twitcher via 'MagpieAdapter' is when requests use the URL endpoint:
+#
+#       <twitcher.url>/<twitcher.ows_proxy_protected_path>/proxy/<service-name>[/...]
+#
 # NOTE: Caching will only take effect with Magpie >= 3.7
 # Detail:
 #   Both 'acl' and 'service' scopes occur on every permission resolution for a given user requesting any access.
@@ -34,6 +40,7 @@ retry.attempts = 3
 #   Caching can be forced reset/ignored by using the 'Cache-Control: no-cache' header during any corresponding request.
 cache.regions = acl, service
 cache.type = memory
+cache.enabled = true
 cache.acl.enabled = true
 cache.acl.expire = 20
 cache.service.enabled = true

--- a/birdhouse/config/twitcher/twitcher.ini.template
+++ b/birdhouse/config/twitcher/twitcher.ini.template
@@ -22,7 +22,7 @@ sqlalchemy.url = sqlite:///%(here)s/twitcher.sqlite
 retry.attempts = 3
 
 # Caching settings for specific sections/functions - improves performance response times of recurring requests
-# Although related to Magpie, cache regions settings executed by 'MagpieAdapter' are running under Twitcher to 
+# Although related to Magpie, cache regions settings executed by 'MagpieAdapter' are running under Twitcher to
 # resolve Access Control Lists to services, and must therefore be placed in Twitcher configuration.
 # NOTE: Caching will only take effect with Magpie >= 3.7
 # Detail:
@@ -35,9 +35,9 @@ retry.attempts = 3
 cache.regions = acl, service
 cache.type = memory
 cache.acl.enabled = true
-cache.acl.expire = 60
+cache.acl.expire = 20
 cache.service.enabled = true
-cache.service.expire = 20
+cache.service.expire = 60
 
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.

--- a/birdhouse/config/twitcher/twitcher.ini.template
+++ b/birdhouse/config/twitcher/twitcher.ini.template
@@ -21,12 +21,21 @@ sqlalchemy.url = sqlite:///%(here)s/twitcher.sqlite
 
 retry.attempts = 3
 
-# caching settings for specific sections/functions
+# Caching settings for specific sections/functions - improves performance response times of recurring requests
+# Although related to Magpie, cache regions settings executed by 'MagpieAdapter' are running under Twitcher to 
+# resolve Access Control Lists to services, and must therefore be placed in Twitcher configuration.
+# NOTE: Caching will only take effect with Magpie >= 3.7
+# Detail:
+#   Both 'acl' and 'service' scopes occur on every permission resolution for a given user requesting any access.
+#   The difference is that 'acl' applies for every combination of (user/group, service/resource, permissions),
+#   while 'service' limits itself to the service name/type resolution from the request path.
+#   Since services are not expected to change often, 'service' cache can be safely increased at a much higher refresh
+#   interval than 'acl' which should re-validate any permission changes more frequently.
+#   Caching be forced reset/ignored by using the 'Cache-Control: no-cache' header during any corresponding request.
 cache.regions = acl, service
 cache.type = memory
 cache.acl.enabled = true
 cache.acl.expire = 60
-# NOTE: following will only take effect with Magpie >= 3.7
 cache.service.enabled = true
 cache.service.expire = 20
 

--- a/birdhouse/config/twitcher/twitcher.ini.template
+++ b/birdhouse/config/twitcher/twitcher.ini.template
@@ -31,7 +31,7 @@ retry.attempts = 3
 #   while 'service' limits itself to the service name/type resolution from the request path.
 #   Since services are not expected to change often, 'service' cache can be safely increased at a much higher refresh
 #   interval than 'acl' which should re-validate any permission changes more frequently.
-#   Caching be forced reset/ignored by using the 'Cache-Control: no-cache' header during any corresponding request.
+#   Caching can be forced reset/ignored by using the 'Cache-Control: no-cache' header during any corresponding request.
 cache.regions = acl, service
 cache.type = memory
 cache.acl.enabled = true

--- a/birdhouse/config/twitcher/twitcher.ini.template
+++ b/birdhouse/config/twitcher/twitcher.ini.template
@@ -83,7 +83,7 @@ listen = 0.0.0.0:8000
 ###
 
 [loggers]
-keys = root, twitcher, sqlalchemy
+keys = root, twitcher, magpie, sqlalchemy
 
 [handlers]
 keys = console
@@ -96,17 +96,29 @@ level = INFO
 handlers = console
 
 [logger_twitcher]
+# "level = DEBUG"   logs detailed information about operations/settings (not for production, will leak sensitive data)
+# "level = INFO"    reports useful information, not leaking details about settings
+# "level = WARN"    only potential problems/unexpected results reported, such as when caching is employed
 level = INFO
 handlers =
 qualname = twitcher
 
+# MagpieAdapter or any other Magpie utilities it employs through Twitcher proxy-adapter security check
+[logger_magpie]
+# "level = DEBUG"   logs detailed information about operations/settings (not for production, will leak sensitive data)
+# "level = INFO"    reports useful information about operations, not leaking details about settings
+# "level = WARN"    only potential problems are reported such as missing settings in configuration
+level = INFO
+handlers =
+qualname = magpie
+
 [logger_sqlalchemy]
+# "level = DEBUG"   logs SQL queries, transactions and results
+# "level = INFO"    logs SQL queries (data can be identified from query field values)
+# "level = WARN"    logs neither (recommended for production systems, avoid anything below unless for dev/debug system)
 level = WARN
 handlers =
 qualname = sqlalchemy.engine
-# "level = INFO" logs SQL queries.
-# "level = DEBUG" logs SQL queries and results.
-# "level = WARN" logs neither.  (Recommended for production systems.)
 
 [handler_console]
 class = StreamHandler

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -14,7 +14,7 @@ export FINCH_IMAGE="birdhouse/finch:version-0.7.4"
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.15"
 
 # Tag version that will be used to update Magpie API, Magpie CLI, and matching Twitcher with Magpie Adapter
-export MAGPIE_VERSION=3.12.0
+export MAGPIE_VERSION=3.14.0
 
 # Root directory under which all data persistence should be nested under
 export DATA_PERSIST_ROOT="/data"


### PR DESCRIPTION
# Overview

Improve response times of Twitcher by caching repeated permission ACL and service resolution in Magpie.

## Changes

**Non-breaking changes**
- Added cache settings of `MagpieAdapter` through Twitcher to improve response times.
  Since caching will occur, any permission update could take up to the configured expire time to take effect. 
  The expire time could be increased or reduced based on usage and how often user/resource/permissions actually change.
  If immediate/force update validation of permissions must be done, `Cache-Control: no-cache` header can be used in the request.

## Related Issue / Discussion

- Resolves [DAC-296](https://www.crim.ca/jira/browse/DAC-296)
- Relates to  bird-house/twitcher#97
- Related new stress test https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/74
