### PR TITLE
jupyter: update for raven notebooks

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210527.1-update20210615"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210527.1-update20210618"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond


### PR DESCRIPTION
To deploy the new Jupyter env to PAVICS.

Given it's an incremental build, these are the only differences:

```diff
>   - intake-geopandas=0.2.4=pyhd8ed1ab_0
>   - intake-thredds=2021.6.16=pyhd8ed1ab_0
>   - intake-xarray=0.5.0=pyhd8ed1ab_0
```

See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/76.