### PR TITLE
Notebook deployment: allow to specify required branch for any tutorial notebook repos in env.local

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,19 +1,19 @@
 [bumpversion]
-current_version = 1.13.10
+current_version = 1.13.11
 commit = True
 tag = False
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.md]
-search =
+search = 
 	[Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 	------------------------------------------------------------------------------------------------------------------
-replace =
+replace = 
 	[Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 	------------------------------------------------------------------------------------------------------------------
-
+	
 	[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
-
+	
 	[{new_version}](https://github.com/bird-house/birdhouse-deploy/tree/{new_version}) ({now:%Y-%m-%d})
 	------------------------------------------------------------------------------------------------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@
     To support testing of this PR
     https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/79.
 
-    - jupyter: minor update to add `unzip` package
+  - jupyter: minor update to add `unzip` package
 
     `unzip` needed to test PAVICS-landing notebooks under Jenkins.  No other
     package updates.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
   - Notebook deployment: allow to specify required branch for any tutorial
     notebook repos in `env.local`.
 
-    Examaple: set `WORKFLOW_TESTS_BRANCH` and any other
+    Example: set `WORKFLOW_TESTS_BRANCH` and any other
     notebook deploy config like `PAVICS_LANDING_BRANCH` in `env.local`.
 
     To support testing of this PR

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.13.11](https://github.com/bird-house/birdhouse-deploy/tree/1.13.11) (2021-07-06)
+------------------------------------------------------------------------------------------------------------------
+
   ###  Changes
 
   - Notebook deployment: allow to specify required branch for any tutorial

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,18 @@
     Examaple: set `WORKFLOW_TESTS_BRANCH` and any other
     notebook deploy config like `PAVICS_LANDING_BRANCH` in `env.local`.
 
+    To support testing of this PR
+    https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/79.
+
+    - jupyter: minor update to add `unzip` package
+
+    `unzip` needed to test PAVICS-landing notebooks under Jenkins.  No other
+    package updates.
+
+    See PR
+    https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/79
+    for more details.
+
 [1.13.10](https://github.com/bird-house/birdhouse-deploy/tree/1.13.10) (2021-06-30)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,13 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+  ###  Changes
+
+  - Notebook deployment: allow to specify required branch for any tutorial
+    notebook repos in `env.local`.
+
+    Examaple: set `WORKFLOW_TESTS_BRANCH` and any other
+    notebook deploy config like `PAVICS_LANDING_BRANCH` in `env.local`.
 
 [1.13.10](https://github.com/bird-house/birdhouse-deploy/tree/1.13.10) (2021-06-30)
 ------------------------------------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.13.10.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.13.11.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.13.10...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.13.11...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.13.10-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.13.11-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.13.10
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.13.11
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210527.1-update20210618"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210527.1-update20210705"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -15,6 +15,22 @@
 LOG_FILE="/var/log/PAVICS/notebookdeploy.log"
 exec >>$LOG_FILE 2>&1
 
+cleanup_on_exit() {
+    rm -rf "$TMPDIR"
+    set +x
+    echo "
+notebookdeploy finished START_TIME=$START_TIME
+notebookdeploy finished   END_TIME=`date -Isecond`"
+}
+
+trap cleanup_on_exit EXIT
+
+START_TIME="`date -Isecond`"
+echo "==========
+notebookdeploy START_TIME=$START_TIME"
+
+set -x
+
 # running script manually (not with cron) source env.local file.
 if [ -z "$COMPOSE_DIR" ]; then
     COMPOSE_DIR="$(dirname -- "$(dirname -- "$(realpath "$0")")")"
@@ -26,16 +42,6 @@ if [ -e "$COMPOSE_DIR/env.local" ]; then
     . "$COMPOSE_DIR/env.local"  # optional override JUPYTERHUB_USER_DATA_DIR
 fi
 
-cleanup_on_exit() {
-    rm -rf "$TMPDIR"
-    set +x
-    echo "
-notebookdeploy finished START_TIME=$START_TIME
-notebookdeploy finished   END_TIME=`date -Isecond`"
-}
-
-trap cleanup_on_exit EXIT
-
 NOTEBOOK_DIR_MNT="/notebook_dir"
 TUTORIAL_NOTEBOOKS_DIR="tutorial-notebooks"
 if [ -z "$WORKFLOW_TESTS_BRANCH" ]; then
@@ -46,12 +52,6 @@ fi
 if [ -z "$TMP_BASE_DIR" ]; then
     TMP_BASE_DIR="/tmp"
 fi
-
-START_TIME="`date -Isecond`"
-echo "==========
-notebookdeploy START_TIME=$START_TIME"
-
-set -x
 
 TMPDIR="`mktemp -d -t notebookdeploy.XXXXXXXXXXXX -p $TMP_BASE_DIR`"
 

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -12,17 +12,19 @@
 #
 # Logs to /var/log/PAVICS/notebookdeploy.log, re-use existing logrotate.
 
-if [ -z "$JUPYTERHUB_USER_DATA_DIR" ]; then
-  # running script manually (not with cron) source env.local file.
-  COMPOSE_DIR="$(dirname -- "$(dirname -- "$(realpath "$0")")")"
-  . "$COMPOSE_DIR/default.env"  # default JUPYTERHUB_USER_DATA_DIR
-  if [ -e "$COMPOSE_DIR/env.local" ]; then
-      . "$COMPOSE_DIR/env.local"  # optional override JUPYTERHUB_USER_DATA_DIR
-  fi
-fi
-
 LOG_FILE="/var/log/PAVICS/notebookdeploy.log"
 exec >>$LOG_FILE 2>&1
+
+# running script manually (not with cron) source env.local file.
+if [ -z "$COMPOSE_DIR" ]; then
+    COMPOSE_DIR="$(dirname -- "$(dirname -- "$(realpath "$0")")")"
+fi
+if [ -e "$COMPOSE_DIR/default.env" ]; then
+    . "$COMPOSE_DIR/default.env"  # default JUPYTERHUB_USER_DATA_DIR
+fi
+if [ -e "$COMPOSE_DIR/env.local" ]; then
+    . "$COMPOSE_DIR/env.local"  # optional override JUPYTERHUB_USER_DATA_DIR
+fi
 
 cleanup_on_exit() {
     rm -rf "$TMPDIR"

--- a/birdhouse/deployment/trigger-deploy-notebook
+++ b/birdhouse/deployment/trigger-deploy-notebook
@@ -39,7 +39,9 @@ if [ -e "$COMPOSE_DIR/default.env" ]; then
     . "$COMPOSE_DIR/default.env"  # default JUPYTERHUB_USER_DATA_DIR
 fi
 if [ -e "$COMPOSE_DIR/env.local" ]; then
+    set +x  # do not leak password in logs
     . "$COMPOSE_DIR/env.local"  # optional override JUPYTERHUB_USER_DATA_DIR
+    set -x
 fi
 
 NOTEBOOK_DIR_MNT="/notebook_dir"


### PR DESCRIPTION
## Changes

**Non-breaking changes**
- Notebook deployment: allow to specify required branch for any tutorial notebook repos in `env.local`
  
  Example: set `WORKFLOW_TESTS_BRANCH` and any other notebook deploy config like `PAVICS_LANDING_BRANCH` in `env.local`

- jupyter: minor update to add `unzip` package                                                                                                   

  `unzip` needed to test PAVICS-landing notebooks under Jenkins.  No other package updates.

To support this PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/79