### PR TITLE
Bump version: 1.13.14 → 1.14.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.13.14
+current_version = 1.14.0
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.14.0](https://github.com/bird-house/birdhouse-deploy/tree/1.14.0) (2021-08-02)
+------------------------------------------------------------------------------------------------------------------
+
   ### Changes
 
   - Add request caching settings in `TWitcher` INI configuration to work with `Magpie` to help reduce permission and

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.13.14.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.14.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.13.14...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.14.0...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.13.14-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.14.0-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.13.14
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.14.0
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)


### PR DESCRIPTION
Following  merge of pull request #182 from bird-house/cache-settings-off

## Overview

Applies the same changes as #174 (cache settings) but disable Twitcher caching explicitly (Magpie caching already disabled).

This is in order to validate that cache settings are applied and tests suite can run successfully with cache disabled, 
to isolate that sporadic errors seen in #174 are related to enabled cache.

## Changes

**Non-breaking changes**
- Added cache settings of `MagpieAdapter` through Twitcher (intended to improve response times, but disabled in this PR).
- Update Magpie/Twitcher version 3.14.0

**Breaking changes**
- Unique user email in Magpie 3.13.0 is enforced, see birdhouse-deploy changelog for how to find them and update the conflicted values before the upgrade.  Otherwise the upgrade will break. See [Magpie 3.13.0 change log](https://pavics-magpie.readthedocs.io/en/3.13.0/changes.html#bug-fixes) for details regarding the introduced unique email restriction.

## Related Issue / Discussion

- Undo resolution of [DAC-296 Twitcher performance issue](https://www.crim.ca/jira/browse/DAC-296) since caching now disabled
- Undo resolution of bird-house/twitcher#97 since cache becomes disabled 
- Based on top of #174 with cache-settings fixes
- Related new stress test Ouranosinc/PAVICS-e2e-workflow-tests#74
