### PR TITLE
re-enable caching feature of twitcher

### DIFF
--- a/birdhouse/config/twitcher/twitcher.ini.template
+++ b/birdhouse/config/twitcher/twitcher.ini.template
@@ -40,10 +40,10 @@ retry.attempts = 3
 #   Caching can be forced reset/ignored by using the 'Cache-Control: no-cache' header during any corresponding request.
 cache.regions = acl, service
 cache.type = memory
-cache.enabled = false
-cache.acl.enabled = false
+cache.enabled = true
+cache.acl.enabled = true
 cache.acl.expire = 20
-cache.service.enabled = false
+cache.service.enabled = true
 cache.service.expire = 60
 
 # By default, the toolbar only appears for clients from IP addresses


### PR DESCRIPTION
## Overview

Re-enables the caching feature of Twitcher that was disabled temporarily in #182 

## Changes

**Non-breaking changes**
- Twitcher request caching=on

**Breaking changes**
n/a

## Related Issue / Discussion

- Resolves https://github.com/Ouranosinc/Magpie/issues/433

