### PR TITLE
jupyter: update for new RavenPy and other new packages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.14.3
+current_version = 1.14.4
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,49 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+  ## Changes
+
+  - Jupyter: update for new RavenPy and other new packages
+
+    Bokeh png export now also works.
+
+    Other noticeable changes:
+    ```diff
+    <   - ravenpy=0.7.0=pyh1bb2064_0
+    >   - ravenpy=0.7.4=pyh7f9bfb9_0
+
+    <   - xclim=0.28.0=pyhd8ed1ab_0
+    >   - xclim=0.28.1=pyhd8ed1ab_0
+
+    >   - geckodriver=0.29.1=h3146498_0
+    >   - selenium=3.141.0=py37h5e8e339_1002
+    >   - nested_dict=1.61=pyhd3deb0d_0
+    >   - paramiko=2.7.2=pyh9f0ad1d_0
+    >   - scp=0.14.0=pyhd8ed1ab_0
+    >   - s3fs=2021.8.1=pyhd8ed1ab_0
+
+    # Downgrade !
+    <   - pandas=1.3.1=py37h219a48f_0
+    >   - pandas=1.2.5=py37h219a48f_0
+
+    <   - owslib=0.24.1=pyhd8ed1ab_0
+    >   - owslib=0.25.0=pyhd8ed1ab_0
+
+    <   - cf_xarray=0.6.0=pyh6c4a22f_0
+    >   - cf_xarray=0.6.1=pyh6c4a22f_0
+
+    <   - rioxarray=0.5.0=pyhd8ed1ab_0
+    >   - rioxarray=0.7.0=pyhd8ed1ab_0
+
+    <   - climpred=2.1.4=pyhd8ed1ab_0
+    >   - climpred=2.1.5.post1=pyhd8ed1ab_0
+
+    <   - dask=2021.7.1=pyhd8ed1ab_0
+    >   - dask=2021.9.0=pyhd8ed1ab_0
+    ```
+
+    See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/89 for more info.
+
 
 [1.14.3](https://github.com/bird-house/birdhouse-deploy/tree/1.14.3) (2021-09-08)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.14.4](https://github.com/bird-house/birdhouse-deploy/tree/1.14.4) (2021-09-10)
+------------------------------------------------------------------------------------------------------------------
+
   ## Changes
 
   - Jupyter: update for new RavenPy and other new packages

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.14.3.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.14.4.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.14.3...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.14.4...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.14.3-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.14.4-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.14.3
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.14.4
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210728"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210908"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond


### PR DESCRIPTION
Bokeh png export now also works.

Other noticeable changes:
```diff
<   - ravenpy=0.7.0=pyh1bb2064_0
>   - ravenpy=0.7.4=pyh7f9bfb9_0

<   - xclim=0.28.0=pyhd8ed1ab_0
>   - xclim=0.28.1=pyhd8ed1ab_0

>   - geckodriver=0.29.1=h3146498_0
>   - selenium=3.141.0=py37h5e8e339_1002
>   - nested_dict=1.61=pyhd3deb0d_0
>   - paramiko=2.7.2=pyh9f0ad1d_0
>   - scp=0.14.0=pyhd8ed1ab_0
>   - s3fs=2021.8.1=pyhd8ed1ab_0

<   - pandas=1.3.1=py37h219a48f_0
>   - pandas=1.2.5=py37h219a48f_0

<   - owslib=0.24.1=pyhd8ed1ab_0
>   - owslib=0.25.0=pyhd8ed1ab_0

<   - cf_xarray=0.6.0=pyh6c4a22f_0
>   - cf_xarray=0.6.1=pyh6c4a22f_0

<   - rioxarray=0.5.0=pyhd8ed1ab_0
>   - rioxarray=0.7.0=pyhd8ed1ab_0

<   - climpred=2.1.4=pyhd8ed1ab_0
>   - climpred=2.1.5.post1=pyhd8ed1ab_0

<   - dask=2021.7.1=pyhd8ed1ab_0
>   - dask=2021.9.0=pyhd8ed1ab_0
```

See PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/89 for more info.