### PR TITLE
scripts: add `extract-jupyter-users-from-magpie-db`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.1
+current_version = 1.17.2
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.17.2](https://github.com/bird-house/birdhouse-deploy/tree/1.17.2) (2021-11-03)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes
 
 - scripts: add `extract-jupyter-users-from-magpie-db`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-### Changes
+## Changes
 
 - scripts: add `extract-jupyter-users-from-magpie-db`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,29 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+### Changes
+
+- scripts: add `extract-jupyter-users-from-magpie-db`
+
+  Extract Jupyter users from Magpie DB so we can send announcements to all Jupyter users.
+
+  Sample output:
+
+  ```
+  $ ./scripts/extract-jupyter-users-from-magpie-db  > /tmp/out
+  + echo SELECT email,user_name FROM users ORDER BY email
+  + docker exec -i postgres-magpie psql -U postgres-magpie magpiedb
+
+  $ cat /tmp/out
+           email          |   user_name
+  ------------------------+---------------
+   admin-catalog@mail.com | admin-catalog
+   admin@mail.com         | admin
+   anonymous@mail.com     | anonymous
+   authtest@example.com   | authtest
+  (4 rows)
+  ```
+
 
 [1.17.0](https://github.com/bird-house/birdhouse-deploy/tree/1.17.0) (2021-11-01)
 ------------------------------------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.1.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.2.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.1...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.2...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.1-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.2-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.1
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.2
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/scripts/extract-jupyter-users-from-magpie-db
+++ b/birdhouse/scripts/extract-jupyter-users-from-magpie-db
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Extract Jupyter users from Magpie DB so we can send announcements to all
+# Jupyter users.
+#
+# Sample output:
+#
+# $ ./scripts/extract-jupyter-users-from-magpie-db  > /tmp/out
+# + echo SELECT email,user_name FROM users ORDER BY email
+# + docker exec -i postgres-magpie psql -U postgres-magpie magpiedb
+#
+# $ cat /tmp/out
+#          email          |   user_name
+# ------------------------+---------------
+#  admin-catalog@mail.com | admin-catalog
+#  admin@mail.com         | admin
+#  anonymous@mail.com     | anonymous
+#  authtest@example.com   | authtest
+# (4 rows)
+
+
+THIS_FILE="`realpath "$0"`"
+THIS_DIR="`dirname "$THIS_FILE"`"
+COMPOSE_DIR="`dirname "$THIS_DIR"`"
+
+if [ -f "$COMPOSE_DIR/default.env" ]; then
+    # Need to source this one first, else sourcing env.local might not work.
+    . "${COMPOSE_DIR}/default.env"
+fi
+
+if [ -f "$COMPOSE_DIR/env.local" ]; then
+    # Get POSTGRES_MAGPIE_USERNAME, MAGPIE_DB_NAME.
+    . "${COMPOSE_DIR}/env.local"
+fi
+
+set -x
+
+echo "SELECT email,user_name FROM users ORDER BY email" | docker exec -i postgres-magpie psql -U $POSTGRES_MAGPIE_USERNAME $MAGPIE_DB_NAME


### PR DESCRIPTION
Extract Jupyter users from Magpie DB so we can send announcements to all Jupyter users.

Sample output:

  ```
  $ ./scripts/extract-jupyter-users-from-magpie-db  > /tmp/out
  + echo SELECT email,user_name FROM users ORDER BY email
  + docker exec -i postgres-magpie psql -U postgres-magpie magpiedb

  $ cat /tmp/out
           email          |   user_name
  ------------------------+---------------
   admin-catalog@mail.com | admin-catalog
   admin@mail.com         | admin
   anonymous@mail.com     | anonymous
   authtest@example.com   | authtest
  (4 rows)
  ```