### PR TITLE
fix mongodb network

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.0
+current_version = 1.17.1
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.17.1](https://github.com/bird-house/birdhouse-deploy/tree/1.17.1) (2021-11-02)
+------------------------------------------------------------------------------------------------------------------
+
 ## Fixes
 
 - Apply ``mongodb`` network to ``mongodb`` image in order to allow ``phoenix`` to properly reference it.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,38 +14,41 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Apply ``mongodb`` network to ``mongodb`` image in order to allow ``phoenix`` to properly reference it.
+- Remove ``mongodb`` definition from ``./components/weaver`` since the extended ``mongodb`` network is already provided.
 
 [1.17.0](https://github.com/bird-house/birdhouse-deploy/tree/1.17.0) (2021-11-01)
 ------------------------------------------------------------------------------------------------------------------
 
-  ### Changes
+## Changes
 
-  - Adds [Weaver](https://github.com/crim-ca/weaver) to the stack (optional) when ``./components/weaver`` 
-    is added to ``EXTRA_CONF_DIRS``. For more details, refer to 
-    [Weaver Component](https://github.com/bird-house/birdhouse-deploy/blob/master/birdhouse/components/README.rst#Weaver)
-    Following happens when enabled:
+- Adds [Weaver](https://github.com/crim-ca/weaver) to the stack (optional) when ``./components/weaver`` 
+  is added to ``EXTRA_CONF_DIRS``. For more details, refer to 
+  [Weaver Component](https://github.com/bird-house/birdhouse-deploy/blob/master/birdhouse/components/README.rst#Weaver)
+  Following happens when enabled:
     
-    * Service ``weaver`` (API) gets added with endpoints ``/twitcher/ows/proxy/weaver`` and ``/weaver``.
+  * Service ``weaver`` (API) gets added with endpoints ``/twitcher/ows/proxy/weaver`` and ``/weaver``.
       
-    * All *birds* offering a WPS 1.x/2.x endpoint are automatically added as providers known by `Weaver`
-      (birds: ``catalog``, ``finch``, ``flyingpigeon``, ``hummingbird``, ``malleefowl`` and ``raven``).
-      This offers an automatic mapping of WPS 1.x/2.x requests of process descriptions and execution nested under
-      the *birds* to corresponding [OGC-API - Processes](https://github.com/opengeospatial/ogcapi-processes/) 
-      RESTful interface (and added functionalities). 
+  * All *birds* offering a WPS 1.x/2.x endpoint are automatically added as providers known by `Weaver`
+    (birds: ``catalog``, ``finch``, ``flyingpigeon``, ``hummingbird``, ``malleefowl`` and ``raven``).
+    This offers an automatic mapping of WPS 1.x/2.x requests of process descriptions and execution nested under
+    the *birds* to corresponding [OGC-API - Processes](https://github.com/opengeospatial/ogcapi-processes/) 
+    RESTful interface (and added functionalities). 
     
-    * New processes can be deployed and executed using 
-      Dockerized [Application Packages](https://pavics-weaver.readthedocs.io/en/latest/package.html).
-      Additionally, all existing processes (across *bird* providers and Dockerized Application Packages) 
-      can be chained into [Workflows](https://pavics-weaver.readthedocs.io/en/latest/processes.html#workflow)
+  * New processes can be deployed and executed using 
+    Dockerized [Application Packages](https://pavics-weaver.readthedocs.io/en/latest/package.html).
+    Additionally, all existing processes (across *bird* providers and Dockerized Application Packages) 
+    can be chained into [Workflows](https://pavics-weaver.readthedocs.io/en/latest/processes.html#workflow)
       
-    * Images ``weaver-worker`` (`Weaver`'s job executor) and ``docker-proxy`` (sibling Docker container dispatcher)
-      are added to the stack to support above functionalities.
+  * Images ``weaver-worker`` (`Weaver`'s job executor) and ``docker-proxy`` (sibling Docker container dispatcher)
+    are added to the stack to support above functionalities.
       
-    * Adds `Magpie` permissions and service for `Weaver` endpoints.
+  * Adds `Magpie` permissions and service for `Weaver` endpoints.
   
-    * Adds ``./optional-components/test-weaver`` for even more `Magpie` extended permissions for `Weaver` 
-      for getting access to resources for functionalities required by [Weaver Testing notebook][weaver-test-notebook].
+  * Adds ``./optional-components/test-weaver`` for even more `Magpie` extended permissions for `Weaver` 
+    for getting access to resources for functionalities required by [Weaver Testing notebook][weaver-test-notebook].
 
 [weaver-test-notebook]: https://github.com/Ouranosinc/pavics-sdi/blob/master/docs/source/notebook-components/weaver_example.ipynb
 

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.0.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.1.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.0...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.1...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.0-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.1-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.0
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.1
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -30,14 +30,6 @@ services:
       - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/permissions/weaver-permissions.cfg:ro
       - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/providers/weaver-provider.cfg:ro
 
-  mongodb:
-    # extend MongoDB to use a shared network that Weaver will be able to access directly
-    # do this as we assume that 'ports' are not exposed, meaning that the DB should be accessible only from that network
-    # also limits external access from other images such as docker container from dispatched execution by workers
-    networks:
-      - mongodb
-    # don't provide volumes, assume that if data persistence was requested, it should be added via another extra compose
-
   # Image 'weaver' is the API side of the application
   weaver:
     container_name: ${WEAVER_MANAGER_NAME}
@@ -81,6 +73,7 @@ services:
     #env_file:
     #  - ./config/mongodb/credentials.env
     depends_on:
+      # no 'default' network here such that the worker is not accessible from proxy/http
       - mongodb
       - weaver  # if not started first, sometimes celery misbehaves and will not pick jobs in queue
       - docker-proxy

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -299,6 +299,8 @@ services:
   mongodb:
     image: mongo:3.4.0
     container_name: mongodb
+    networks:
+      - mongodb
     volumes:
       - ${DATA_PERSIST_ROOT}/mongodb_persist:/data/db
     # Mongodb crash with permission denied errors if the command is not overridden like this


### PR DESCRIPTION
## Overview

Move `mongodb` network to `mongodb` image directly and update `phoenix`/`weaver` images accordingly.

## Changes

**Non-breaking changes**
- Apply ``mongodb`` network to ``mongodb`` image in order to allow ``phoenix`` to properly reference it.
- Remove ``mongodb`` definition from ``./components/weaver`` since the extended ``mongodb`` network is already provided.

**Breaking changes**
- n/a

## Related Issue / Discussion

- Resolves https://github.com/bird-house/birdhouse-deploy/pull/114#discussion_r740666666

