### PR TITLE
Minor fix to `install-docker.sh` and comment update for other scripts due to Magpie upgrade

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.2
+current_version = 1.17.3
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,14 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- Minor fix to `install-docker.sh` and comment update for other scripts due to Magpie upgrade
+
+`install-docker.sh`: fix to work with users with sudo priviledge.  Before it needed user `root`.
+
+Other scripts are due to new Magpie in PR https://github.com/bird-house/birdhouse-deploy/pull/107.
+
 
 [1.16.0](https://github.com/bird-house/birdhouse-deploy/tree/1.16.0) (2021-10-20)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,13 +14,13 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-## Changes
+## Fixes
 
 - Minor fix to `install-docker.sh` and comment update for other scripts due to Magpie upgrade
 
-`install-docker.sh`: fix to work with users with sudo priviledge.  Before it needed user `root`.
+  `install-docker.sh`: fix to work with users with sudo priviledge.  Before it needed user `root`.
 
-Other scripts are due to new Magpie in PR https://github.com/bird-house/birdhouse-deploy/pull/107.
+  Other comments in scripts are due to new Magpie in PR https://github.com/bird-house/birdhouse-deploy/pull/107.
 
 
 [1.17.2](https://github.com/bird-house/birdhouse-deploy/tree/1.17.2) (2021-11-03)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.17.3](https://github.com/bird-house/birdhouse-deploy/tree/1.17.3) (2021-11-03)
+------------------------------------------------------------------------------------------------------------------
+
 ## Fixes
 
 - Minor fix to `install-docker.sh` and comment update for other scripts due to Magpie upgrade

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.2.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.3.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.2...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.3...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.2-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.3-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.2
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.3
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/scripts/bootstrap-instance-for-testsuite
+++ b/birdhouse/scripts/bootstrap-instance-for-testsuite
@@ -14,9 +14,11 @@ THIS_DIR="`dirname "$THIS_FILE"`"
 
 set -x
 # Populate test .nc file on Thredds.
+# Need to open temporary Thredds "testdata/secure/" on PAVICS production to anonymous group.
 $THIS_DIR/bootstrap-testdata
 
 # Index Thredds catalog.
+# Need to open temporary Thredds "testdata/secure/" on local PAVICS host to anonymous group.
 $THIS_DIR/trigger-pavicscrawler
 
 # For crawler to complete, assuming minimal dataset from bootstrap-testdata so
@@ -24,6 +26,7 @@ $THIS_DIR/trigger-pavicscrawler
 sleep 5
 
 # Create test user.
+# Need "optional-components/secure-thredds" activated to pre-create group thredds-secure-authtest-group.
 $THIS_DIR/create-magpie-authtest-user
 
 # Check if instance properly provisionned for testsuite.

--- a/birdhouse/scripts/bootstrap-instance-for-testsuite
+++ b/birdhouse/scripts/bootstrap-instance-for-testsuite
@@ -15,6 +15,7 @@ THIS_DIR="`dirname "$THIS_FILE"`"
 set -x
 # Populate test .nc file on Thredds.
 # Need to open temporary Thredds "testdata/secure/" on PAVICS production to anonymous group.
+# Need write-access to DATASET_ROOT (/data/datasets/).
 $THIS_DIR/bootstrap-testdata
 
 # Index Thredds catalog.

--- a/birdhouse/scripts/bootstrap-testdata
+++ b/birdhouse/scripts/bootstrap-testdata
@@ -6,6 +6,8 @@
 #
 # To be run locally on the host running Thredds.  Will populate test data files
 # under DATASET_ROOT, customizable by env var.
+#
+# Need write-access to DATASET_ROOT (/data/datasets/).
 
 
 if [ -z "$DATASET_ROOT" ]; then

--- a/birdhouse/scripts/bootstrap-testdata
+++ b/birdhouse/scripts/bootstrap-testdata
@@ -2,6 +2,8 @@
 # Bootstrap minimum test data on Thredds.
 # To run testsuite in https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests.
 #
+# Need to open temporary Thredds "testdata/secure/" on PAVICS production to anonymous group.
+#
 # To be run locally on the host running Thredds.  Will populate test data files
 # under DATASET_ROOT, customizable by env var.
 

--- a/birdhouse/scripts/create-magpie-authtest-user
+++ b/birdhouse/scripts/create-magpie-authtest-user
@@ -2,6 +2,8 @@
 # Create authtest user for testsuite at
 # https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests.
 #
+# Need "optional-components/secure-thredds" activated to pre-create group thredds-secure-authtest-group.
+#
 # Options:
 #   -d: delete user 'authtest' instead of creating it
 

--- a/birdhouse/scripts/trigger-pavicscrawler
+++ b/birdhouse/scripts/trigger-pavicscrawler
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Trigger pavicscrawler on local PAVICS host.
 #
+# Need to open temporary Thredds "testdata/secure/" on local PAVICS host to anonymous group.
+#
 # pavicscrawler is a method of the catalog WPS service to index Thredds
 # catalog into Solr DB for quick searching.
 #

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -90,7 +90,7 @@ fi
 
 # Add /usr/local/bin to PATH of all users, even root user, so docker-compose
 # can be found.
-echo 'export PATH="$PATH:/usr/local/bin"' > /etc/profile.d/usr_local_path.sh
+echo 'export PATH="$PATH:/usr/local/bin"' | sudo tee /etc/profile.d/usr_local_path.sh
 
 # install docker-compose, from https://gist.github.com/wdullaer/f1af16bd7e970389bad3
 LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -v refs/tags/v | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"|tail -1`"


### PR DESCRIPTION
Found when trying to bring up the new production host for PAVICS.

`install-docker.sh`: fix to work with users with sudo priviledge.  Before it needed user `root`.

Other comments in scripts are due to new Magpie in PR https://github.com/bird-house/birdhouse-deploy/pull/107.
