### PR TITLE
ignore generated weaver_config under canarie-api

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.3
+current_version = 1.17.4
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@
 
 - Minor fix to `install-docker.sh` and comment update for other scripts due to Magpie upgrade
 
-  `install-docker.sh`: fix to work with users with sudo priviledge.  Before it needed user `root`.
+  `install-docker.sh`: fix to work with users with sudo privilege.  Before it needed user `root`.
 
   Other comments in scripts are due to new Magpie in PR https://github.com/bird-house/birdhouse-deploy/pull/107.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@
 - Add missing ``config/canarie-api/weaver_config.py`` entry to ``.gitignore`` of ``./components/weaver``
   that is generated from the corresponding template file.
 
+  If upgrading from previous `1.17.x` version, autodeploy will not resume automatically even with this fix because of 
+  the *dirty* state of the repository. A manual `git pull` will be required to fix subsequent autodeploy triggers.
+
 [1.17.2](https://github.com/bird-house/birdhouse-deploy/tree/1.17.2) (2021-11-03)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,10 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Add missing ``config/canarie-api/weaver_config.py`` entry to ``.gitignore`` of ``./components/weaver``
+  that is generated from the corresponding template file.
 
 [1.17.2](https://github.com/bird-house/birdhouse-deploy/tree/1.17.2) (2021-11-03)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.17.4](https://github.com/bird-house/birdhouse-deploy/tree/1.17.4) (2021-11-03)
+------------------------------------------------------------------------------------------------------------------
+
 ## Fixes
 
 - Add missing ``config/canarie-api/weaver_config.py`` entry to ``.gitignore`` of ``./components/weaver``

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.3.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.4.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.3...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.4...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.3-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.4-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.3
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.4
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/components/weaver/.gitignore
+++ b/birdhouse/components/weaver/.gitignore
@@ -1,4 +1,5 @@
 conf.extra-service.d/weaver.conf
+config/canarie-api/weaver_config.py
 config/magpie/config.yml
 config/weaver/data_sources.yml
 config/weaver/request_options.yml


### PR DESCRIPTION
## Changes

**Non-breaking changes**
- Add missing ``config/canarie-api/weaver_config.py`` entry to ``.gitignore`` of ``./components/weaver``
  that is generated from the corresponding template file.

**Breaking changes**
- n/a

## Related Issue / Discussion

- Resolves https://github.com/bird-house/birdhouse-deploy/pull/114#discussion_r741553883

