### PR TITLE
Update Finch to v0.7.7

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.4
+current_version = 1.17.5
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,12 @@
 
 [//]: # (list changes here, using '-' for each new entry, remove this when items are added)
 
+[1.17.5](https://github.com/bird-house/birdhouse-deploy/tree/1.17.5) (2021-11-16)
+
+## Changes
+- Upgrade Finch to 0.7.6
+  [Release notes](https://github.com/bird-house/finch/releases/tag/v0.7.6)
+
 [1.17.4](https://github.com/bird-house/birdhouse-deploy/tree/1.17.4) (2021-11-03)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.17.5](https://github.com/bird-house/birdhouse-deploy/tree/1.17.5) (2021-11-16)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes
 - Upgrade Finch to 0.7.7
   [Release notes for 0.7.7](https://github.com/bird-house/finch/releases/tag/v0.7.7)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,14 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
-
-[1.17.5](https://github.com/bird-house/birdhouse-deploy/tree/1.17.5) (2021-11-16)
-
 ## Changes
-- Upgrade Finch to 0.7.6
-  [Release notes](https://github.com/bird-house/finch/releases/tag/v0.7.6)
-
+- Upgrade Finch to 0.7.7
+  [Release notes for 0.7.7](https://github.com/bird-house/finch/releases/tag/v0.7.7)
+- [Release notes 0.7.6](https://github.com/bird-house/finch/releases/tag/v0.7.6)
+  
 [1.17.4](https://github.com/bird-house/birdhouse-deploy/tree/1.17.4) (2021-11-03)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 ## Changes
 - Upgrade Finch to 0.7.7
   [Release notes for 0.7.7](https://github.com/bird-house/finch/releases/tag/v0.7.7)
-- [Release notes 0.7.6](https://github.com/bird-house/finch/releases/tag/v0.7.6)
+- [Release notes for 0.7.6](https://github.com/bird-house/finch/releases/tag/v0.7.6)
   
 [1.17.4](https://github.com/bird-house/birdhouse-deploy/tree/1.17.4) (2021-11-03)
 ------------------------------------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.4.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.17.5.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.4...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.17.5...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.4-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.17.5-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.4
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.17.5
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -9,7 +9,7 @@ export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210908"
 # to the order of the DOCKER_NOTEBOOK_IMAGES variable
 export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics"
 
-export FINCH_IMAGE="birdhouse/finch:version-0.7.6"
+export FINCH_IMAGE="birdhouse/finch:version-0.7.7"
 
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.15"
 

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -9,7 +9,7 @@ export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210908"
 # to the order of the DOCKER_NOTEBOOK_IMAGES variable
 export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics"
 
-export FINCH_IMAGE="birdhouse/finch:version-0.7.5"
+export FINCH_IMAGE="birdhouse/finch:version-0.7.6"
 
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.15"
 


### PR DESCRIPTION
## Overview

## Changes

**Non-breaking changes**
- New component version Finch:0.7.7

## Related Issue / Discussion

## Additional Information

Revert "added SENTRY_ENV environment variable" by @matprov in #213
Refresh notebooks by @Zeitsperre in https://github.com/bird-house/finch/pull/201
Add SENTRY_ENV param by @matprov in https://github.com/bird-house/finch/pull/203
Multiple rcps for ensemble processes by @aulemahal in https://github.com/bird-house/finch/pull/202
Remove bugging drop after geoserver upgrade by @aulemahal in https://github.com/bird-house/finch/pull/207
Update to xclim 0.31 by @aulemahal in https://github.com/bird-house/finch/pull/209
Fix xarray, dask and gunicorn related hang by @cjauvin in https://github.com/bird-house/finch/pull/204
run load() before switching to single-threaded scheduler by @huard in https://github.com/bird-house/finch/pull/211
Add average flag for ensemble processes by @aulemahal in https://github.com/bird-house/finch/pull/210
Revert "added SENTRY_ENV environment variable" by @matprov in https://github.com/bird-house/finch/pull/213


