### PR TITLE
Bump version: 1.18.2 → 1.18.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.2
+current_version = 1.18.3
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.3](https://github.com/bird-house/birdhouse-deploy/tree/1.18.3) (2021-12-17)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 - Jupyter: new build with latest changes
 

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.2.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.3.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.2...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.3...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.2-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.3-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.2
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.3
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)


### PR DESCRIPTION
Forgot to bump version in previous PR https://github.com/bird-house/birdhouse-deploy/pull/229 "Matching PR to deploy new Jupyter to PAVICS.".

See Jupyter build PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/94 for more info.