### PR TITLE
upgrade Finch to 0.8.0

### DIFF
--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -9,7 +9,7 @@ export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:211123-update211216"
 # to the order of the DOCKER_NOTEBOOK_IMAGES variable
 export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics"
 
-export FINCH_IMAGE="birdhouse/finch:version-0.7.7"
+export FINCH_IMAGE="birdhouse/finch:version-0.8.0"
 
 # thredds-docker >= 4.6.18 or >= 5.2 strongly recommended to avoid Log4J CVE-2021-44228.
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.18"


### PR DESCRIPTION
## Overview

Please include a summary of the changes and which issues are fixed. 

Please also include relevant motivation and context. 

List any dependencies that are required for this change.

## Changes

**Non-breaking changes**

- Updated changelog by @matprov 
- Add hourly_to_daily process by @huard 
- Avoid annoying warnings by updating birdy (environment-docs) by @huard 
- Upgrade to clisops 0.8.0 to accelerate spatial averages over regions.
- Upgrade to xesmf 0.6.2 to fix spatial averaging bug not weighing correctly cells with varing areas.
- Update to PyWPS 4.5.1 to allow the creation of recursive directories for outputs.

**Breaking changes**

## Related Issue / Discussion

- Should allow custom nested directories to be configured for outputs (see #11 &  #203)

- Corresponding notebook changes: https://github.com/Ouranosinc/pavics-sdi/pull/244

## Additional Information

