### PR TITLE
Vagrant: Support RockyLinux

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.3
+current_version = 1.18.4
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,18 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+- vagrant: support RockyLinux
+
+  RockyLinux 8 is the successor to Centos 7.
+
+  Centos 8 has become like a "RHEL 8 beta" than the equivalent of RHEL 8.
+
+  RockyLinux 8 is the new equivalent of RHEL 8, following the original spirit
+  of the Centos project.
+
+  More info at https://rockylinux.org/about.
+
 
 [1.18.3](https://github.com/bird-house/birdhouse-deploy/tree/1.18.3) (2021-12-17)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.4](https://github.com/bird-house/birdhouse-deploy/tree/1.18.4) (2022-01-25)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 - vagrant: support RockyLinux
 

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.3.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.4.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.3...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.4...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.3-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.4-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.3
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.4
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,13 @@ Vagrant.configure("2") do |config|
 
   # bug https://github.com/hashicorp/vagrant/issues/3341 still happening as of
   # 2019-07-03 with VirtualBox 6.0.8
-  config.vbguest.auto_update = false
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    # vagrant plugin list
+    # vagrant vbguest --status
+    # vagrant vbguest --do install  # manual re-install if OS update wiped it
+    # Sometime manual re-install do not work, best to take a VM snapshot before OS update for rollback.
+    config.vbguest.auto_update = false
+  end
 
   # https://blog.centos.org/2018/01/updated-centos-vagrant-images-available-v1801-01/
   # Fix /vagrant shared folders (together with vagrant-vbguest) for Centos 7.

--- a/birdhouse/vagrant-utils/configure-pagekite
+++ b/birdhouse/vagrant-utils/configure-pagekite
@@ -4,7 +4,7 @@ ACCOUNT_CONF="/etc/pagekite.d/10_account.rc"
 
 if [ -n "$KITENAME" -a -n "$KITESECRET" -a -n "$KITESUBDOMAIN" ]; then
 
-    if ! grep centos /etc/os-release; then
+    if ! grep centos /etc/os-release && ! grep rocky /etc/os-release; then
         DEBIAN_FRONTEND=noninteractive apt-get install --yes pagekite
     else
         yum install --assumeyes epel-release
@@ -26,7 +26,7 @@ EOF
 else
 
     DISABLE_PAGEKITE=""
-    if ! grep centos /etc/os-release; then
+    if ! grep centos /etc/os-release && ! grep rocky /etc/os-release; then
         if dpkg -l pagekite; then
             DISABLE_PAGEKITE=true
         fi

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -93,7 +93,7 @@ fi
 echo 'export PATH="$PATH:/usr/local/bin"' | sudo tee /etc/profile.d/usr_local_path.sh
 
 # install docker-compose, from https://gist.github.com/wdullaer/f1af16bd7e970389bad3
-LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -v refs/tags/v | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"|tail -1`"
+LATEST_COMPOSE_VERSION="`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "v[0-9]+\.[0-9]\.[0-9]+$"|tail -1`"
 # LATEST_COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)  # need jq :(
 sudo curl -L "https://github.com/docker/compose/releases/download/$LATEST_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -3,7 +3,7 @@
 set -e # Exit if any subcommand fails
 set -x # Print commands for troubleshooting
 
-if ! grep centos /etc/os-release; then
+if ! grep centos /etc/os-release && ! grep rocky /etc/os-release; then
 
     # Install Docker CE on Ubuntu per
     # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/

--- a/vagrant_variables.yml.example
+++ b/vagrant_variables.yml.example
@@ -74,4 +74,4 @@ domain: ouranos.ca
 # disksize: '100GB'
 # box: 'ubuntu/bionic64'  # no manual steps required
 # box: 'centos/7'  # will require manual 'vagrant-utils/disk-resize' inside box
-# box: 'rockylinux/8'
+# box: 'rockylinux/8'  # will require manual 'vagrant-utils/disk-resize' inside box

--- a/vagrant_variables.yml.example
+++ b/vagrant_variables.yml.example
@@ -74,3 +74,4 @@ domain: ouranos.ca
 # disksize: '100GB'
 # box: 'ubuntu/bionic64'  # no manual steps required
 # box: 'centos/7'  # will require manual 'vagrant-utils/disk-resize' inside box
+# box: 'rockylinux/8'


### PR DESCRIPTION
RockyLinux 8 is the successor to Centos 7.

Centos 8 has become like a "RHEL 8 beta" than the equivalent of RHEL 8.

RockyLinux 8 is the new equivalent of RHEL 8, following the original spirit of the Centos project.

More info at https://rockylinux.org/about.