### PR TITLE
Jupyter: update Jupyter env for latest XClim, RavenPy and all packages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.4
+current_version = 1.18.5
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.5](https://github.com/bird-house/birdhouse-deploy/tree/1.18.5) (2022-01-27)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 - Jupyter: update Jupyter env for latest XClim, RavenPy and all packages
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,70 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+- Jupyter: update Jupyter env for latest XClim, RavenPy and all packages
+
+  Deploy new Jupyter env from PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/95 on PAVICS.
+
+  Detailed changes can be found at https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/95.
+
+  Relevant changes:
+  ```diff
+  <   - xclim=0.31.0=pyhd8ed1ab_0
+  >   - xclim=0.32.1=pyhd8ed1ab_0
+  
+  <   - ravenpy=0.7.5=pyhff6ddc9_0
+  >   - ravenpy=0.7.8=pyh8a188c0_0
+  
+  <   - python=3.7.12=hb7a2778_100_cpython
+  >   - python=3.8.12=hb7a2778_2_cpython
+  
+  # removed
+  <   - vcs=8.2.1=pyh9f0ad1d_0
+  
+  <   - numpy=1.21.4=py37h31617e3_0
+  >   - numpy=1.21.5=py38h87f13fb_0
+  
+  <   - xarray=0.20.1=pyhd8ed1ab_0
+  >   - xarray=0.20.2=pyhd8ed1ab_0
+  
+  <   - rioxarray=0.8.0=pyhd8ed1ab_0
+  >   - rioxarray=0.9.1=pyhd8ed1ab_0
+  
+  <   - cf_xarray=0.6.1=pyh6c4a22f_0
+  >   - cf_xarray=0.6.3=pyhd8ed1ab_0
+  
+  <   - gdal=3.3.2=py37hd5a0ba4_2
+  >   - gdal=3.3.3=py38hcf2042a_0
+  
+  <   - rasterio=1.2.6=py37hc20819c_2
+  >   - rasterio=1.2.10=py38hfd64e68_0
+  
+  <   - climpred=2.1.6=pyhd8ed1ab_1
+  >   - climpred=2.2.0=pyhd8ed1ab_0
+  
+  <   - clisops=0.7.0=pyh6c4a22f_0
+  >   - clisops=0.8.0=pyh6c4a22f_0
+  
+  <   - xesmf=0.6.0=pyhd8ed1ab_0
+  >   - xesmf=0.6.2=pyhd8ed1ab_0
+  
+  <   - birdy=v0.8.0=pyh6c4a22f_1
+  >   - birdy=0.8.1=pyh6c4a22f_1
+  
+  <   - cartopy=0.20.0=py37hbe109c4_0
+  >   - cartopy=0.20.1=py38hf9a4893_1
+  
+  <   - dask=2021.11.2=pyhd8ed1ab_0
+  >   - dask=2022.1.0=pyhd8ed1ab_0
+  
+  <   - numba=0.53.1=py37hb11d6e1_1
+  >   - numba=0.55.0=py38h4bf6c61_0
+  
+  <   - pandas=1.3.4=py37he8f5f7f_1
+  >   - pandas=1.3.5=py38h43a58ef_0
+  ```
+
 
 [1.18.4](https://github.com/bird-house/birdhouse-deploy/tree/1.18.4) (2022-01-25)
 ------------------------------------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.4.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.5.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.4...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.5...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.4-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.5-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.4
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.5
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:211123-update211216"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220121"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond


### PR DESCRIPTION
Deploy new Jupyter env from PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/95 on PAVICS.

Detailed changes can be found at https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/95.

Relevant changes:
```diff
<   - xclim=0.31.0=pyhd8ed1ab_0
>   - xclim=0.32.1=pyhd8ed1ab_0

<   - ravenpy=0.7.5=pyhff6ddc9_0
>   - ravenpy=0.7.8=pyh8a188c0_0

<   - python=3.7.12=hb7a2778_100_cpython
>   - python=3.8.12=hb7a2778_2_cpython

<   - vcs=8.2.1=pyh9f0ad1d_0

<   - numpy=1.21.4=py37h31617e3_0
>   - numpy=1.21.5=py38h87f13fb_0

<   - xarray=0.20.1=pyhd8ed1ab_0
>   - xarray=0.20.2=pyhd8ed1ab_0

<   - rioxarray=0.8.0=pyhd8ed1ab_0
>   - rioxarray=0.9.1=pyhd8ed1ab_0

<   - cf_xarray=0.6.1=pyh6c4a22f_0
>   - cf_xarray=0.6.3=pyhd8ed1ab_0

<   - gdal=3.3.2=py37hd5a0ba4_2
>   - gdal=3.3.3=py38hcf2042a_0

<   - rasterio=1.2.6=py37hc20819c_2
>   - rasterio=1.2.10=py38hfd64e68_0

<   - climpred=2.1.6=pyhd8ed1ab_1
>   - climpred=2.2.0=pyhd8ed1ab_0

<   - clisops=0.7.0=pyh6c4a22f_0
>   - clisops=0.8.0=pyh6c4a22f_0

<   - xesmf=0.6.0=pyhd8ed1ab_0
>   - xesmf=0.6.2=pyhd8ed1ab_0

<   - birdy=v0.8.0=pyh6c4a22f_1
>   - birdy=0.8.1=pyh6c4a22f_1

<   - cartopy=0.20.0=py37hbe109c4_0
>   - cartopy=0.20.1=py38hf9a4893_1

<   - dask=2021.11.2=pyhd8ed1ab_0
>   - dask=2022.1.0=pyhd8ed1ab_0

<   - numba=0.53.1=py37hb11d6e1_1
>   - numba=0.55.0=py38h4bf6c61_0

<   - pandas=1.3.4=py37he8f5f7f_1
>   - pandas=1.3.5=py38h43a58ef_0
```