### PR TITLE
Update finch to v0.8.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.8
+current_version = 1.18.9
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,29 @@
 
 [//]: # (list changes here, using '-' for each new entry, remove this when items are added)
 
+[1.18.9](https://github.com/bird-house/birdhouse-deploy/tree/1.18.8) (2022-03-16)
+------------------------------------------------------------------------------------------------------------------
+
+## Changes:
+
+- Finch: update `finch` component 
+  from [0.7.7](https://github.com/bird-house/finch/releases/tag/v0.7.7)
+  to [0.8.2](https://github.com/bird-house/finch/releases/tag/v0.8.2)
+
+  Relevant Changes:
+  - v0.8.0
+    - Add hourly_to_daily process
+    - Avoid annoying warnings by updating birdy (environment-docs)
+    - Upgrade to clisops 0.8.0 to accelerate spatial averages over regions. 
+    - Upgrade to xesmf 0.6.2 to fix spatial averaging bug not weighing correctly cells with varying areas. 
+    - Update to PyWPS 4.5.1 to allow the creation of recursive directories for outputs.
+  - v0.8.2
+    - Add ``geoseries_to_netcdf`` process, converting a geojson (like a OGC-API request) to a CF-compliant netCDF. 
+    - Add ``output_name`` argument to most processes (excepted subsetting and averaging processes), to control 
+      the name (or prefix) of the output file. 
+    - New dependency ``python-slugify`` to ensure filenames are safe and valid. 
+    - Pinning dask to ``<=2022.1.0`` to avoid a performance issue with ``2022.1.1``.
+
 [1.18.8](https://github.com/bird-house/birdhouse-deploy/tree/1.18.8) (2022-03-09)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,11 +19,6 @@
 [1.18.9](https://github.com/bird-house/birdhouse-deploy/tree/1.18.9) (2022-03-16)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
-
-[1.18.9](https://github.com/bird-house/birdhouse-deploy/tree/1.18.8) (2022-03-16)
-------------------------------------------------------------------------------------------------------------------
-
 ## Changes:
 
 - Finch: update `finch` component 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,11 @@
 
 [//]: # (list changes here, using '-' for each new entry, remove this when items are added)
 
+[1.18.9](https://github.com/bird-house/birdhouse-deploy/tree/1.18.9) (2022-03-16)
+------------------------------------------------------------------------------------------------------------------
+
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
 [1.18.9](https://github.com/bird-house/birdhouse-deploy/tree/1.18.8) (2022-03-16)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.8.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.9.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.8...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.9...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.8-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.9-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.8
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.9
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -9,7 +9,7 @@ export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220121"
 # to the order of the DOCKER_NOTEBOOK_IMAGES variable
 export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics"
 
-export FINCH_IMAGE="birdhouse/finch:version-0.7.7"
+export FINCH_IMAGE="birdhouse/finch:version-0.8.2"
 
 # thredds-docker >= 4.6.18 or >= 5.2 strongly recommended to avoid Log4J CVE-2021-44228.
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.18"


### PR DESCRIPTION
## Overview

Please include a summary of the changes and which issues are fixed. 

Please also include relevant motivation and context. 

List any dependencies that are required for this change.

## Changes

- Finch: update `finch` component 
  from [0.7.7](https://github.com/bird-house/finch/releases/tag/v0.7.7)
  to [0.8.2](https://github.com/bird-house/finch/releases/tag/v0.8.2)

  Relevant Changes:
  - v0.8.0
    - Add hourly_to_daily process
    - Avoid annoying warnings by updating birdy (environment-docs)
    - Upgrade to clisops 0.8.0 to accelerate spatial averages over regions. 
    - Upgrade to xesmf 0.6.2 to fix spatial averaging bug not weighing correctly cells with varying areas. 
    - Update to PyWPS 4.5.1 to allow the creation of recursive directories for outputs.
  - v0.8.2
    - Add ``geoseries_to_netcdf`` process, converting a geojson (like a OGC-API request) to a CF-compliant netCDF. 
    - Add ``output_name`` argument to most processes (excepted subsetting and averaging processes), to control 
      the name (or prefix) of the output file. 
    - New dependency ``python-slugify`` to ensure filenames are safe and valid. 
    - Pinning dask to ``<=2022.1.0`` to avoid a performance issue with ``2022.1.1``.

## Related Issue / Discussion

- Resolves https://github.com/bird-house/finch/issues/230
- Needed https://github.com/Ouranosinc/pavics-sdi/pull/252

## Additional Information
