### PR TITLE
update weaver 4.5.0 -> 4.12.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.6
+current_version = 1.18.7
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@
   - Adds [Vault](https://pavics-weaver.readthedocs.io/en/latest/processes.html#vault) functionality allowing temporary
     and secure storage to upload files for single-use process execution.
   - Various bugfixes and conformance resolution related to [OGC API - Processes][ogcapi-proc].
+  - Fix `weaver-mongodb` link references for `weaver-worker`. New default variables `WEAVER_MONGODB_[HOST|PORT|URL]`
+    are defined to construct different INI configuration formats employed by `weaver` and `weaver-worker` images.
+  - Fix missing `EXTRA_VARS` variables in [Weaver's default.env](./birdhouse/components/weaver/default.env).
 
 [ogcapi-proc]: https://github.com/opengeospatial/ogcapi-processes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.7](https://github.com/bird-house/birdhouse-deploy/tree/1.18.7) (2022-03-08)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 - Weaver: update `weaver` component
   from [4.5.0](https://github.com/crim-ca/weaver/tree/4.5.0)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,14 +15,14 @@
 ------------------------------------------------------------------------------------------------------------------
 
 ## Changes:
-- Weaver: update `weaver` component 
-  from [4.5.0](https://github.com/crim-ca/weaver/tree/4.5.0) 
+- Weaver: update `weaver` component
+  from [4.5.0](https://github.com/crim-ca/weaver/tree/4.5.0)
   to [4.12.0](https://github.com/crim-ca/weaver/tree/4.12.0).
 
   Relevant changes:
   - Adds `WeaverClient` and *Weaver CLI*. Although not strictly employed by the platform itself to offer *Weaver* as a
-    service, these can be employed to interact with *Weaver* using Python or shell commands, providing access to all 
-    WPS *birds* offered by the platform using the common [OGC API - Processes][ogcapi-proc] interface through 
+    service, these can be employed to interact with *Weaver* using Python or shell commands, providing access to all
+    WPS *birds* offered by the platform using the common [OGC API - Processes][ogcapi-proc] interface through
     [Weaver Providers](https://pavics-weaver.readthedocs.io/en/latest/processes.html#remote-provider).
   - Adds [Vault](https://pavics-weaver.readthedocs.io/en/latest/processes.html#vault) functionality allowing temporary
     and secure storage to upload files for single-use process execution.
@@ -30,7 +30,7 @@
   - Fix `weaver-mongodb` link references for `weaver-worker`. New default variables `WEAVER_MONGODB_[HOST|PORT|URL]`
     are defined to construct different INI configuration formats employed by `weaver` and `weaver-worker` images.
   - Fix missing `EXTRA_VARS` variables in [Weaver's default.env](./birdhouse/components/weaver/default.env).
-  - Fix [celery-healthcheck](./birdhouse/components/weaver/celery-healthcheck) of `weaver-worker` to consider 
+  - Fix [celery-healthcheck](./birdhouse/components/weaver/celery-healthcheck) of `weaver-worker` to consider
     multiple tasks.
 
 [ogcapi-proc]: https://github.com/opengeospatial/ogcapi-processes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@
   - Fix `weaver-mongodb` link references for `weaver-worker`. New default variables `WEAVER_MONGODB_[HOST|PORT|URL]`
     are defined to construct different INI configuration formats employed by `weaver` and `weaver-worker` images.
   - Fix missing `EXTRA_VARS` variables in [Weaver's default.env](./birdhouse/components/weaver/default.env).
+  - Fix [celery-healthcheck](./birdhouse/components/weaver/celery-healthcheck) of `weaver-worker` to consider 
+    multiple tasks.
 
 [ogcapi-proc]: https://github.com/opengeospatial/ogcapi-processes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,21 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+- Weaver: update `weaver` component 
+  from [4.5.0](https://github.com/crim-ca/weaver/tree/4.5.0) 
+  to [4.12.0](https://github.com/crim-ca/weaver/tree/4.12.0).
+
+  Relevant changes:
+  - Adds `WeaverClient` and *Weaver CLI*. Although not strictly employed by the platform itself to offer *Weaver* as a
+    service, these can be employed to interact with *Weaver* using Python or shell commands, providing access to all 
+    WPS *birds* offered by the platform using the common [OGC API - Processes][ogcapi-proc] interface through 
+    [Weaver Providers](https://pavics-weaver.readthedocs.io/en/latest/processes.html#remote-provider).
+  - Adds [Vault](https://pavics-weaver.readthedocs.io/en/latest/processes.html#vault) functionality allowing temporary
+    and secure storage to upload files for single-use process execution.
+  - Various bugfixes and conformance resolution related to [OGC API - Processes][ogcapi-proc].
+
+[ogcapi-proc]: https://github.com/opengeospatial/ogcapi-processes
 
 [1.18.5](https://github.com/bird-house/birdhouse-deploy/tree/1.18.5) (2022-01-27)
 ------------------------------------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.6.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.7.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.6...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.7...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.6-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.7-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.6
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.7
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/components/weaver/celery-healthcheck
+++ b/birdhouse/components/weaver/celery-healthcheck
@@ -10,25 +10,34 @@ if [[ -z "${result}" ]]; then
   exit 1
 fi
 
-# should look like:
+# should look like (minimally):
 #   [... weaver-logs ...]
 #   -> celery@<uuid>: OK
 #       * weaver.processes.execution.execute_process
-result=$(echo "${result}" | tail -n 2)
-status=$(echo "${result}" | head -n 1)
-task=$(echo "${result}" | tail -n 1)
+# more tasks possible depending on Weaver version and enabled features
+celery_status_index=$(echo "${result}" | grep --line-number -E '^-> celery' | cut -d ':' -f 1)
+if [[ -z "${celery_status_index}" ]]; then
+  echo "${ERROR}Empty Celery status."
+  exit 1
+fi
+celery_status_tasks=$(($(echo "${result}" | wc -l) - celery_status_index))
+celery_status_lines=$((celery_status_tasks + 1))
+celery_status_result=$(echo "${result}" | tail -n ${celery_status_lines})
+celery_status=$(echo "${celery_status_result}" | head -n 1)
+celery_tasks=$(echo "${celery_status_result}" | tail -n ${celery_status_tasks})
 
 echo "${INFO}Celery inspect results dump:"
-echo "${result}"
+echo "${celery_status_result}"
 
-if [[ $(echo "${status}" | grep -c "OK") -ne 1 ]]; then
+if [[ $(echo "${celery_status}" | grep -c "OK") -ne 1 ]]; then
   echo "${ERROR}Celery inspect did not return expected 'OK' status."
   exit 2
 fi
-if [[ $(echo "${task}" | grep -c "weaver.processes.execution.execute_process") -ne 1 ]]; then
+# validate only the task that is always required
+if [[ $(echo "${celery_tasks}" | grep -c "weaver.processes.execution.execute_process") -ne 1 ]]; then
   echo "${ERROR}Celery inspect did not retrieve expected task."
   exit 3
 fi
 
-echo "${INFO}Success. Celery Task is ready."
+echo "${INFO}Success. Celery Worker is ready."
 exit 0

--- a/birdhouse/components/weaver/config/weaver/weaver.ini.template
+++ b/birdhouse/components/weaver/config/weaver/weaver.ini.template
@@ -18,8 +18,8 @@ pyramid.debug_routematch = false
 pyramid.default_locale_name = en
 
 # mongodb
-mongodb.host = weaver-mongodb
-mongodb.port = 27017
+mongodb.host = ${WEAVER_MONGODB_HOST}
+mongodb.port = ${WEAVER_MONGODB_PORT}
 mongodb.db_name = weaver
 
 # --- Weaver Configuration ---
@@ -102,8 +102,8 @@ weaver.extra_options =
 ###
 [celery]
 use_celeryconfig = false
-broker_url = mongodb://mongodb:27017/celery
-result_backend = mongodb://mongodb:27017/
+broker_url = ${WEAVER_MONGODB_URL}/celery
+result_backend = ${WEAVER_MONGODB_URL}/
 
 # following is technically redundant, but Weaver-API sporadically doesn't correctly discover tasks
 # enforce the import location to make sure they are detected and tasks submission can be registered in workers

--- a/birdhouse/components/weaver/config/weaver/weaver.ini.template
+++ b/birdhouse/components/weaver/config/weaver/weaver.ini.template
@@ -85,6 +85,10 @@ weaver.wps_email_notify_ssl = true
 weaver.wps_email_notify_template_dir =
 weaver.wps_email_notify_template_default =
 
+# --- Weaver vault configuration ---
+weaver.vault = true
+weaver.vault_dir = /tmp/vault
+
 # --- Weaver other configurations ---
 # default WPS processes to always preload
 weaver.wps_processes_file = wps_processes.yml

--- a/birdhouse/components/weaver/default.env
+++ b/birdhouse/components/weaver/default.env
@@ -6,6 +6,11 @@
 # single quotes are important in below list to keep variable names intact until 'pavics-compose' parses them
 EXTRA_VARS='
   $WEAVER_CONFIG
+  $WEAVER_VERSION
+  $WEAVER_MONGODB_VERSION
+  $WEAVER_MONGODB_HOST
+  $WEAVER_MONGODB_PORT
+  $WEAVER_MONGODB_URL
   $WEAVER_MANAGER_NAME
   $WEAVER_WORKER_NAME
   $WEAVER_WPS_NAME
@@ -33,8 +38,15 @@ export WEAVER_CONFIG=HYBRID
 export WEAVER_VERSION=4.12.0
 
 # default release of the MongoDB version employed by Weaver
-# note that MongoDB>=5.0 is REQUIRED for Weaver>=4.5.0
+# NOTE:
+#   MongoDB>=5.0 is REQUIRED for Weaver>=4.5.0
 export WEAVER_MONGODB_VERSION=5.0.4
+# URL is used by both Weaver API and Celery Worker
+# it should contain the docker service name as host to map using shared link between images
+# if credentials are desired, they can be defined with the override of the URL variable
+export WEAVER_MONGODB_HOST=weaver-mongodb
+export WEAVER_MONGODB_PORT=27017
+export WEAVER_MONGODB_URL=mongodb://${WEAVER_MONGODB_HOST}:${WEAVER_MONGODB_PORT}
 
 # real names of the weaver/worker services
 # 'WEAVER_MANAGER_NAME' value will generate "<server-fqdn>/<name>" URI to access its API behind secured proxy

--- a/birdhouse/components/weaver/default.env
+++ b/birdhouse/components/weaver/default.env
@@ -30,7 +30,7 @@ VARS="$VARS $EXTRA_VARS"
 export WEAVER_CONFIG=HYBRID
 
 # default release version that will be used to fetch docker images (API mananger & celery workers services)
-export WEAVER_VERSION=4.5.0
+export WEAVER_VERSION=4.12.0
 
 # default release of the MongoDB version employed by Weaver
 # note that MongoDB>=5.0 is REQUIRED for Weaver>=4.5.0

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -122,8 +122,6 @@ services:
       - weaver-mongodb
     volumes:
       - ${DATA_PERSIST_ROOT}/mongodb_weaver_persist:/data/db
-    # Mongodb crash with permission denied errors if the command is not overridden like this
-    command: bash -c 'chown -R mongodb:mongodb /data && chmod -R 755 /data && mongod'
     restart: always
     logging: *default-logging
 

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -111,7 +111,7 @@ services:
       # Weaver API will not have registered the execution tasks until then.
       start_period: 30s
       interval: 60s
-      timeout: 10s
+      timeout: 20s
       retries: 2
 
   # Dedicated database for Weaver, since other 'mongodb' image does not employ the same version.


### PR DESCRIPTION
## Overview

Weaver: update `weaver` component from [4.5.0](https://github.com/crim-ca/weaver/tree/4.5.0) to [4.12.0](https://github.com/crim-ca/weaver/tree/4.12.0).

## Changes

**Non-breaking changes**
  - Adds `WeaverClient` and *Weaver CLI*. Although not strictly employed by the platform itself to offer *Weaver* as a
    service, these can be employed to interact with *Weaver* using Python or shell commands, providing access to all 
    WPS *birds* offered by the platform using the common [OGC API - Processes][ogcapi-proc] interface through 
    [Weaver Providers](https://pavics-weaver.readthedocs.io/en/latest/processes.html#remote-provider).
  - Adds [Vault](https://pavics-weaver.readthedocs.io/en/latest/processes.html#vault) functionality allowing temporary
    and secure storage to upload files for single-use process execution.
  - Various bugfixes and conformance resolution related to [OGC API - Processes][ogcapi-proc].
  - Fix `weaver-mongodb` link references for `weaver-worker`. New default variables `WEAVER_MONGODB_[HOST|PORT|URL]`
    are defined to construct different INI configuration formats employed by `weaver` and `weaver-worker` images.
  - Fix missing `EXTRA_VARS` variables in [Weaver's default.env](./birdhouse/components/weaver/default.env).

**Breaking changes**
- n/a

## Related Issue / Discussion

- Resolves https://www.crim.ca/jira/browse/DAC-455
