### PR TITLE
update magpie 3.19.1 -> 3.21.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.5
+current_version = 1.18.6
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,22 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+- Magpie: update `magpie` service
+  from [3.19.1](https://github.com/Ouranosinc/Magpie/tree/3.19.1)
+  to [3.21.0](https://github.com/Ouranosinc/Magpie/tree/3.21.0).
+
+  Relevant changes:
+  - Update *WFS*, *WMS* and *WPS* related services to properly implement the relevant *Permissions* and *Resources*
+    according to their specific implementation details. For example, *GeoServer*-based *WMS* implementation supports
+    *Workspaces* and additional operations that are not offered by standard *OGC*-based *WMS*. Some of these
+    implementation specific operations can be taken advantage of with improved *Permissions* and *Resources* resolution.
+  - Add multi-*Resource* effective access resolution for *Services* that support it.
+    For example, accessing multiple *Layers* under a permission-restricted *WFS* with parameters that allow multiple
+    values within a single request is now possible, if the user is granted to all specified *Resources*.
+    Previously, users would require to access each *Layer Resource* individually with distinct requests.
+  - Magpie's API and UI are more verbose about supported hierarchical *Resource* structure under a given *Service* type.
+    When creating *Resources*, specific structures have to be respected, and only valid cases are proposed in the UI.
+  - Minor UI fixes.
 
 [1.18.5](https://github.com/bird-house/birdhouse-deploy/tree/1.18.5) (2022-01-27)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.6](https://github.com/bird-house/birdhouse-deploy/tree/1.18.6) (2022-03-08)
+------------------------------------------------------------------------------------------------------------------
+
 - Magpie: update `magpie` service
   from [3.19.1](https://github.com/Ouranosinc/Magpie/tree/3.19.1)
   to [3.21.0](https://github.com/Ouranosinc/Magpie/tree/3.21.0).

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.5.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.6.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.5...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.6...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.5-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.6-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.5
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.6
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -22,7 +22,7 @@ export GEOSERVER_IMAGE="pavics/geoserver:2.19.0-kartoza-build20210329"
 export BASH_IMAGE="bash:5.1.4"
 
 # Tag version that will be used to update Magpie API, Magpie CLI, and matching Twitcher with Magpie Adapter
-export MAGPIE_VERSION=3.19.1
+export MAGPIE_VERSION=3.21.0
 
 # Root directory under which all data persistence should be nested under
 export DATA_PERSIST_ROOT="/data"


### PR DESCRIPTION
## Overview

Magpie: update `magpie` service from [3.19.1](https://github.com/Ouranosinc/Magpie/tree/3.19.1) to [3.21.0](https://github.com/Ouranosinc/Magpie/tree/3.21.0).

## Changes

**Non-breaking changes**
  - Update *WFS*, *WMS* and *WPS* related services to properly implement the relevant *Permissions* and *Resources*
    according to their specific implementation details. For example, *GeoServer*-based *WMS* implementation supports
    *Workspaces* and additional operations that are not offered by standard *OGC*-based *WMS*. Some of these
    implementation specific operations can be taken advantage of with improved *Permissions* and *Resources* resolution.
  - Add multi-*Resource* effective access resolution for *Services* that support it.
    For example, accessing multiple *Layers* under a permission-restricted *WFS* with parameters that allow multiple
    values within a single request is now possible, if the user is granted to all specified *Resources*.
    Previously, users would require to access each *Layer Resource* individually with distinct requests.
  - Magpie's API and UI are more verbose about supported hierarchical *Resource* structure under a given *Service* type.
    When creating *Resources*, specific structures have to be respected, and only valid cases are proposed in the UI.
  - Minor UI fixes.

**Breaking changes**
- None expected.

  _**Note:**_ 
  Modified services by the new version add permissions that were previously missing, or remove permissions that would yield an error anyway since the corresponding operations are undefined in the underlying service. 
  If issues are faced due to those changes, it is most probably because incorrect service types were employed, or unexpected/unintended behaviour were taken advantage of.

## Related Issue / Discussion

- Resolves https://www.crim.ca/jira/browse/DAC-151
