### PR TITLE
Increase default startup timeout needed to setup default WPS providers

### DIFF
--- a/birdhouse/components/weaver/default.env
+++ b/birdhouse/components/weaver/default.env
@@ -87,4 +87,4 @@ export WEAVER_WPS_PROVIDERS="
     raven
 "
 # control maximum timeout to abandon registration (duration in seconds)
-export WEAVER_WPS_PROVIDERS_MAX_TIME=60
+export WEAVER_WPS_PROVIDERS_MAX_TIME=120


### PR DESCRIPTION
## Overview

Increase default startup timeout needed to setup default WPS providers.

Test instances always manage to register `catalog`, `finch`, and `flyingpigeon` providers, before timing out for `hummingbird`. 
https://github.com/bird-house/birdhouse-deploy/blob/master/birdhouse/components/weaver/default.env#L81-L88

Because of this, all tests in https://github.com/Ouranosinc/pavics-sdi/blob/master/docs/source/notebook-components/weaver_example.ipynb fail due to missing WPS birds.

## Changes

**Non-breaking changes**
- Increase default timeout (`60s -> 120s`) for https://github.com/bird-house/birdhouse-deploy/blob/master/birdhouse/components/weaver/post-docker-compose-up to complete.

**Breaking changes**
- n/a

