### PR TITLE
jupyter env: new xlrd, pre-commit, pin dask, distributed, cf_xarray, latest of everything else

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.9
+current_version = 1.18.10
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,47 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+
+- Jupyter env: new xlrd, pre-commit, pin dask, distributed, cf_xarray, latest of everything else
+
+  Deploy new Jupyter env from PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/101 on PAVICS.
+
+  Detailed changes can be found at https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/101.
+
+  Relevant changes:
+  ```diff
+  >   - pre-commit=2.17.0=py38h578d9bd_0
+  >   - xlrd=2.0.1=pyhd8ed1ab_3
+  
+  <   - xclim=0.32.1=pyhd8ed1ab_0
+  >   - xclim=0.34.0=pyhd8ed1ab_0
+  
+  <   - cfgrib=0.9.9.1=pyhd8ed1ab_1
+  >   - cfgrib=0.9.10.1=pyhd8ed1ab_0
+  
+  <   - cftime=1.5.1.1=py38h6c62de6_1
+  >   - cftime=1.6.0=py38h3ec907f_0
+  
+  <   - intake-xarray=0.5.0=pyhd8ed1ab_0
+  >   - intake-xarray=0.6.0=pyhd8ed1ab_0
+  
+  <   - pandas=1.3.5=py38h43a58ef_0
+  >   - pandas=1.4.1=py38h43a58ef_0
+  
+  <   - regionmask=0.8.0=pyhd8ed1ab_1
+  >   - regionmask=0.9.0=pyhd8ed1ab_0
+  
+  <   - rioxarray=0.9.1=pyhd8ed1ab_0
+  >   - rioxarray=0.10.3=pyhd8ed1ab_0
+  
+  <   - xarray=0.20.2=pyhd8ed1ab_0
+  >   - xarray=2022.3.0=pyhd8ed1ab_0
+  
+  <   - zarr=2.10.3=pyhd8ed1ab_0
+  >   - zarr=2.11.1=pyhd8ed1ab_0
+  ```
+
 
 [1.18.9](https://github.com/bird-house/birdhouse-deploy/tree/1.18.9) (2022-03-16)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.10](https://github.com/bird-house/birdhouse-deploy/tree/1.18.10) (2022-04-07)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 
 - Jupyter env: new xlrd, pre-commit, pin dask, distributed, cf_xarray, latest of everything else

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.9.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.10.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.9...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.10...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.9-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.10-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.9
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.10
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220121"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220401"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond


### PR DESCRIPTION
  Deploy new Jupyter env from PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/101 on PAVICS.

  Detailed changes can be found at https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/101.

  Relevant changes:
  ```diff
  >   - pre-commit=2.17.0=py38h578d9bd_0
  >   - xlrd=2.0.1=pyhd8ed1ab_3
  
  <   - xclim=0.32.1=pyhd8ed1ab_0
  >   - xclim=0.34.0=pyhd8ed1ab_0
  
  <   - cfgrib=0.9.9.1=pyhd8ed1ab_1
  >   - cfgrib=0.9.10.1=pyhd8ed1ab_0
  
  <   - cftime=1.5.1.1=py38h6c62de6_1
  >   - cftime=1.6.0=py38h3ec907f_0
  
  <   - intake-xarray=0.5.0=pyhd8ed1ab_0
  >   - intake-xarray=0.6.0=pyhd8ed1ab_0
  
  <   - pandas=1.3.5=py38h43a58ef_0
  >   - pandas=1.4.1=py38h43a58ef_0
  
  <   - regionmask=0.8.0=pyhd8ed1ab_1
  >   - regionmask=0.9.0=pyhd8ed1ab_0
  
  <   - rioxarray=0.9.1=pyhd8ed1ab_0
  >   - rioxarray=0.10.3=pyhd8ed1ab_0
  
  <   - xarray=0.20.2=pyhd8ed1ab_0
  >   - xarray=2022.3.0=pyhd8ed1ab_0
  
  <   - zarr=2.10.3=pyhd8ed1ab_0
  >   - zarr=2.11.1=pyhd8ed1ab_0
  ```

