### PR TITLE
jupyter env: new build for new XClim and to get Dask dashboard and Panel server app to work

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.11
+current_version = 1.18.12
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.12](https://github.com/bird-house/birdhouse-deploy/tree/1.18.12) (2022-05-05)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 
 - Jupyter env: new build for new XClim and to get Dask dashboard and Panel server app to work

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,34 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+
+- Jupyter env: new build for new XClim and to get Dask dashboard and Panel server app to work
+
+  Deploy new Jupyter env from PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/105 on PAVICS.
+
+  Detailed changes can be found at https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/105.
+
+  Dask dashboard and Panel server app work both by manually mapping `http://localhost:<PORT>` to
+  `https://pavics.ouranos.ca/jupyter/user/<USER>/proxy/<PORT>` as seen in screenshots below:
+
+  ![Screenshot from 2022-04-12 15-20-58](https://user-images.githubusercontent.com/11966697/163259294-97337abd-91e6-4832-b639-d7d2e89c353d.png) 
+
+  ![Screenshot from 2022-04-12 16-29-06](https://user-images.githubusercontent.com/11966697/163264000-c2d0f993-8d4d-4eeb-8fa7-0cdce454c2f4.png)
+
+  Relevant changes:
+
+  ```diff
+  >   - dask-labextension=5.2.0=pyhd8ed1ab_0
+  >   - jupyter-server-proxy=3.2.1=pyhd8ed1ab_0
+  
+  <   - xclim=0.34.0=pyhd8ed1ab_0
+  >   - xclim=0.35.0=pyhd8ed1ab_0
+  
+  <   - pandas=1.4.1=py38h43a58ef_0
+  >   - pandas=1.4.2=py38h47df419_1
+  ```
+
 
 [1.18.10](https://github.com/bird-house/birdhouse-deploy/tree/1.18.10) (2022-04-07)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,24 +22,52 @@
 
   Detailed changes can be found at https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/105.
 
-  Dask dashboard and Panel server app work both by manually mapping `http://localhost:<PORT>` to
-  `https://pavics.ouranos.ca/jupyter/user/<USER>/proxy/<PORT>` as seen in screenshots below:
+  Dask dashboard no manual URL mangling required:
 
-  ![Screenshot from 2022-04-12 15-20-58](https://user-images.githubusercontent.com/11966697/163259294-97337abd-91e6-4832-b639-d7d2e89c353d.png) 
+  ![Screenshot from 2022-04-13 22-37-49](https://user-images.githubusercontent.com/11966697/163303916-f781ac23-d10a-4cd6-807c-b10c8703afc3.png)
 
-  ![Screenshot from 2022-04-12 16-29-06](https://user-images.githubusercontent.com/11966697/163264000-c2d0f993-8d4d-4eeb-8fa7-0cdce454c2f4.png)
+  "Render with Panel" button works:
+  ![Screenshot from 2022-05-04 15-18-03](https://user-images.githubusercontent.com/11966697/166810160-f6989da4-6e8f-4407-8fd5-4ef71770e1f2.png)
+
 
   Relevant changes:
 
   ```diff
+  # new
   >   - dask-labextension=5.2.0=pyhd8ed1ab_0
+  >   - jupyter-panel-proxy=0.2.0a2=py_0
   >   - jupyter-server-proxy=3.2.1=pyhd8ed1ab_0
   
-  <   - xclim=0.34.0=pyhd8ed1ab_0
-  >   - xclim=0.35.0=pyhd8ed1ab_0
+  # removed, interfere with panel
+  <     - handcalcs==1.4.1
   
+  <   - xclim=0.34.0=pyhd8ed1ab_0
+  >   - xclim=0.36.0=pyhd8ed1ab_0
+  
+  <   - cf_xarray=0.6.3=pyhd8ed1ab_0
+  >   - cf_xarray=0.7.2=pyhd8ed1ab_0
+  
+  <   - clisops=0.8.0=pyh6c4a22f_0
+  >   - clisops=0.9.0=pyh6c4a22f_0
+  
+  # downgrade by clisops
   <   - pandas=1.4.1=py38h43a58ef_0
-  >   - pandas=1.4.2=py38h47df419_1
+  >   - pandas=1.3.5=py38h43a58ef_0
+  
+  <   - rioxarray=0.10.3=pyhd8ed1ab_0
+  >   - rioxarray=0.11.1=pyhd8ed1ab_0
+  
+  <   - nc-time-axis=1.4.0=pyhd8ed1ab_0
+  >   - nc-time-axis=1.4.1=pyhd8ed1ab_0
+  
+  <   - roocs-utils=0.5.0=pyh6c4a22f_0
+  >   - roocs-utils=0.6.1=pyh6c4a22f_0
+  
+  <   - panel=0.12.7=pyhd8ed1ab_0
+  >   - panel=0.13.1a2=py_0
+  
+  <   - plotly=5.6.0=pyhd8ed1ab_0
+  >   - plotly=5.7.0=pyhd8ed1ab_0
   ```
 
 

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.11.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.12.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.11...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.12...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.11-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.12-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.11
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.12
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -62,6 +62,7 @@ c.DockerSpawner.environment = {
     # Issue https://github.com/bokeh/bokeh/issues/12090
     # Post on Panel forum:
     # https://discourse.holoviz.org/t/how-to-customize-the-display-url-from-panel-serve-for-use-behind-jupyterhub-with-jupyter-server-proxy/3571
+    # Issue about Panel Preview: https://github.com/holoviz/panel/issues/3440
     "PAVICS_HOST_URL": "https://${PAVICS_FQDN_PUBLIC}",
     # https://docs.dask.org/en/stable/configuration.html
     # https://jupyterhub-on-hadoop.readthedocs.io/en/latest/dask.html

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -58,7 +58,10 @@ container_home_dir = join(container_workspace_dir, ".home")
 c.DockerSpawner.notebook_dir = notebook_dir
 c.DockerSpawner.environment = {
     "HOME": container_home_dir,
-    "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN}",
+    # https://docs.bokeh.org/en/latest/docs/reference/command/subcommands/serve.html
+    "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN_PUBLIC}",
+    # https://docs.dask.org/en/stable/configuration.html
+    "DASK_DISTRIBUTED__DASHBOARD__LINK": "https://${PAVICS_FQDN_PUBLIC}{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"
 }
 
 c.DockerSpawner.volumes = {host_user_data_dir: container_workspace_dir}

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -58,8 +58,6 @@ container_home_dir = join(container_workspace_dir, ".home")
 c.DockerSpawner.notebook_dir = notebook_dir
 c.DockerSpawner.environment = {
     "HOME": container_home_dir,
-    # https://docs.bokeh.org/en/latest/docs/reference/command/subcommands/serve.html
-    "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN_PUBLIC}",
     # https://docs.bokeh.org/en/latest/docs/user_guide/jupyter.html#jupyterhub
     # Issue https://github.com/bokeh/bokeh/issues/12090
     # Post on Panel forum:

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -57,7 +57,8 @@ container_home_dir = join(container_workspace_dir, ".home")
 
 c.DockerSpawner.notebook_dir = notebook_dir
 c.DockerSpawner.environment = {
-    "HOME": container_home_dir
+    "HOME": container_home_dir,
+    "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN}",
 }
 
 c.DockerSpawner.volumes = {host_user_data_dir: container_workspace_dir}

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -61,6 +61,7 @@ c.DockerSpawner.environment = {
     # https://docs.bokeh.org/en/latest/docs/reference/command/subcommands/serve.html
     "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN_PUBLIC}",
     # https://docs.bokeh.org/en/latest/docs/user_guide/jupyter.html#jupyterhub
+    # Issue https://github.com/bokeh/bokeh/issues/12090
     "JUPYTERHUB_EXTERNAL_BASE_URL": "https://${PAVICS_FQDN_PUBLIC}",
     # https://docs.dask.org/en/stable/configuration.html
     # https://jupyterhub-on-hadoop.readthedocs.io/en/latest/dask.html

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -60,6 +60,8 @@ c.DockerSpawner.environment = {
     "HOME": container_home_dir,
     # https://docs.bokeh.org/en/latest/docs/reference/command/subcommands/serve.html
     "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN_PUBLIC}",
+    # https://docs.bokeh.org/en/latest/docs/user_guide/jupyter.html#jupyterhub
+    "JUPYTERHUB_EXTERNAL_BASE_URL": "https://${PAVICS_FQDN_PUBLIC}",
     # https://docs.dask.org/en/stable/configuration.html
     # https://jupyterhub-on-hadoop.readthedocs.io/en/latest/dask.html
     "DASK_DISTRIBUTED__DASHBOARD__LINK": "https://${PAVICS_FQDN_PUBLIC}{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -61,6 +61,7 @@ c.DockerSpawner.environment = {
     # https://docs.bokeh.org/en/latest/docs/reference/command/subcommands/serve.html
     "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN_PUBLIC}",
     # https://docs.dask.org/en/stable/configuration.html
+    # https://jupyterhub-on-hadoop.readthedocs.io/en/latest/dask.html
     "DASK_DISTRIBUTED__DASHBOARD__LINK": "https://${PAVICS_FQDN_PUBLIC}{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"
 }
 

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -62,6 +62,8 @@ c.DockerSpawner.environment = {
     "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN_PUBLIC}",
     # https://docs.bokeh.org/en/latest/docs/user_guide/jupyter.html#jupyterhub
     # Issue https://github.com/bokeh/bokeh/issues/12090
+    # Post on Panel forum:
+    # https://discourse.holoviz.org/t/how-to-customize-the-display-url-from-panel-serve-for-use-behind-jupyterhub-with-jupyter-server-proxy/3571
     "PAVICS_HOST_URL": "https://${PAVICS_FQDN_PUBLIC}",
     # https://docs.dask.org/en/stable/configuration.html
     # https://jupyterhub-on-hadoop.readthedocs.io/en/latest/dask.html

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -62,7 +62,7 @@ c.DockerSpawner.environment = {
     "BOKEH_ALLOW_WS_ORIGIN": "${PAVICS_FQDN_PUBLIC}",
     # https://docs.bokeh.org/en/latest/docs/user_guide/jupyter.html#jupyterhub
     # Issue https://github.com/bokeh/bokeh/issues/12090
-    "JUPYTERHUB_EXTERNAL_BASE_URL": "https://${PAVICS_FQDN_PUBLIC}",
+    "PAVICS_HOST_URL": "https://${PAVICS_FQDN_PUBLIC}",
     # https://docs.dask.org/en/stable/configuration.html
     # https://jupyterhub-on-hadoop.readthedocs.io/en/latest/dask.html
     "DASK_DISTRIBUTED__DASHBOARD__LINK": "https://${PAVICS_FQDN_PUBLIC}{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220401"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220412"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220426"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220427"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220428.1"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220502"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220427"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220428.1"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220412"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220422"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -2,7 +2,7 @@
 # All env in this default.env must not depend on any env in env.local.
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220422"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220426"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond


### PR DESCRIPTION
  Deploy new Jupyter env from PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/105 on PAVICS.

  Detailed changes can be found at https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/105.

  Dask dashboard no manual URL mangling required:

![Screenshot from 2022-04-13 22-37-49](https://user-images.githubusercontent.com/11966697/163303916-f781ac23-d10a-4cd6-807c-b10c8703afc3.png)

"Render with Panel" button works:
![Screenshot from 2022-05-04 15-18-03](https://user-images.githubusercontent.com/11966697/166810160-f6989da4-6e8f-4407-8fd5-4ef71770e1f2.png)

  Relevant changes:

```diff
# new
>   - dask-labextension=5.2.0=pyhd8ed1ab_0
>   - jupyter-panel-proxy=0.2.0a2=py_0
>   - jupyter-server-proxy=3.2.1=pyhd8ed1ab_0

# removed, interfere with panel
<     - handcalcs==1.4.1

<   - xclim=0.34.0=pyhd8ed1ab_0
>   - xclim=0.36.0=pyhd8ed1ab_0

<   - cf_xarray=0.6.3=pyhd8ed1ab_0
>   - cf_xarray=0.7.2=pyhd8ed1ab_0

<   - clisops=0.8.0=pyh6c4a22f_0
>   - clisops=0.9.0=pyh6c4a22f_0

# downgrade by clisops
<   - pandas=1.4.1=py38h43a58ef_0
>   - pandas=1.3.5=py38h43a58ef_0

<   - rioxarray=0.10.3=pyhd8ed1ab_0
>   - rioxarray=0.11.1=pyhd8ed1ab_0

<   - nc-time-axis=1.4.0=pyhd8ed1ab_0
>   - nc-time-axis=1.4.1=pyhd8ed1ab_0

<   - roocs-utils=0.5.0=pyh6c4a22f_0
>   - roocs-utils=0.6.1=pyh6c4a22f_0

<   - panel=0.12.7=pyhd8ed1ab_0
>   - panel=0.13.1a2=py_0

<   - plotly=5.6.0=pyhd8ed1ab_0
>   - plotly=5.7.0=pyhd8ed1ab_0
```