### PR TITLE
finch: new release for dask performance problem

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.10
+current_version = 1.18.11
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.11](https://github.com/bird-house/birdhouse-deploy/tree/1.18.11) (2022-04-21)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 
 - Finch: new release for dask performance problem

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,21 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+
+- Finch: new release for dask performance problem
+
+  PR to deploy new Finch releases in https://github.com/bird-house/finch/pull/233 on PAVICS.
+
+  See the Finch PR for more info.
+
+  Finch release notes:
+
+  0.8.3 (2022-04-21)
+  ------------------
+  * Preserve RCP dimension in ensemble processes, even when only RCP is selected.
+  * Pin ``dask`` and ``distributed`` at ``2022.1.0``, see https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/100
+
 
 [1.18.10](https://github.com/bird-house/birdhouse-deploy/tree/1.18.10) (2022-04-07)
 ------------------------------------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.10.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.11.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.10...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.11...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.10-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.11-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.10
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.11
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -9,7 +9,7 @@ export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220401"
 # to the order of the DOCKER_NOTEBOOK_IMAGES variable
 export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics"
 
-export FINCH_IMAGE="birdhouse/finch:version-0.8.2"
+export FINCH_IMAGE="birdhouse/finch:version-0.8.3"
 
 # thredds-docker >= 4.6.18 or >= 5.2 strongly recommended to avoid Log4J CVE-2021-44228.
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.18"


### PR DESCRIPTION
PR to deploy new Finch releases in https://github.com/bird-house/finch/pull/233 on PAVICS.

See the Finch PR for more info.

Finch release notes:

0.8.3 (2022-04-21)
------------------
* Preserve RCP dimension in ensemble processes, even when only RCP is selected.

* Pin ``dask`` and ``distributed`` at ``2022.1.0``, see https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/100
