### PR TITLE
magpie/twitcher/weaver requests hooks for WPS outputs in user workspace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,22 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+
+- Magpie/Twitcher: update `magpie` service
+  from [3.21.0](https://github.com/Ouranosinc/Magpie/tree/3.21.0)
+  to [3.25.0](https://github.com/Ouranosinc/Magpie/tree/3.25.0) and 
+  bundled `twitcher` from [0.6.2](https://github.com/bird-house/twitcher/tree/v0.6.2)
+  to [0.7.0](https://github.com/bird-house/twitcher/tree/v0.7.0).
+  
+  - Adds [Service Hooks](https://pavics-magpie.readthedocs.io/en/latest/configuration.html#service-hooks) allowing 
+    Twitcher to apply HTTP pre-request/post-response modifications to requested services and resources in accordance
+    to `MagpieAdapter` implementation and using plugin Python scripts when matched against specific request parameters.
+
+  - Using *Service Hooks*, inject ``X-WPS-Output-Context`` header in Weaver job submission requests through the proxied
+    request by Twitcher and `MagpieAdapter`. This header contains the user ID that indicates to Weaver were to store 
+    job output results, allowing to save them in the corresponding user's workspace directory under `wpsoutputs` path.
+
 
 [1.18.12](https://github.com/bird-house/birdhouse-deploy/tree/1.18.12) (2022-05-05)
 ------------------------------------------------------------------------------------------------------------------
@@ -3314,4 +3329,3 @@ Prior Versions
 All versions prior to [1.7.0](https://github.com/bird-house/birdhouse-deploy/tree/1.7.0) were not officially tagged.
 Is it strongly recommended employing later versions to ensure better traceability of changes that could impact behavior
 and potential issues on new server instances. 
-

--- a/birdhouse/components/weaver/config/magpie/adapter_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/adapter_hooks.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyramid.request import Request
+
+    from magpie.typedefs import ServiceConfigItem
+
+
+def add_x_wps_output_context(request, service):
+    # type: (Request, ServiceConfigItem) -> Request
+    if "application/json" in request.content_type:
+        body = request.json  # JSON generated from body, cannot override directly
+        # following for testing purposes only
+        body["hooks"] = len(service["hooks"])
+        body["hook"] = "add_x_wps_output_context"
+        request.body = json.dumps(body).encode()
+    if request.user is not None:
+        request.headers["X-WPS-Output-Context"] = "user-" + str(request.user.id)
+    return request

--- a/birdhouse/components/weaver/config/magpie/adapter_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/adapter_hooks.py
@@ -1,22 +1,45 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import json
+"""
+These hooks will be running within Twitcher, using MagpieAdapter context.
+
+The code below can make use of any package that is installed by Magpie/Twitcher.
+"""
+
 from typing import TYPE_CHECKING
+
+from magpie.constants import get_constant
+from magpie.utils import get_header
 
 if TYPE_CHECKING:
     from pyramid.request import Request
 
-    from magpie.typedefs import ServiceConfigItem
+
+def is_admin(request):
+    # type: (Request) -> bool
+    admin_group = get_constant("MAGPIE_ADMIN_GROUP", settings_container=request)
+    return admin_group in [group.group_name for group in request.user.groups]
 
 
-def add_x_wps_output_context(request, service):
-    # type: (Request, ServiceConfigItem) -> Request
-    if "application/json" in request.content_type:
-        body = request.json  # JSON generated from body, cannot override directly
-        # following for testing purposes only
-        body["hooks"] = len(service["hooks"])
-        body["hook"] = "add_x_wps_output_context"
-        request.body = json.dumps(body).encode()
-    if request.user is not None:
-        request.headers["X-WPS-Output-Context"] = "user-" + str(request.user.id)
+def add_x_wps_output_context(request):
+    # type: (Request) -> Request
+    """
+    Apply the ``X-WPS-Output-Context`` for saving outputs in the user-context WPS-outputs directory.
+    """
+    header = get_header("X-WPS-Output-Context", request.headers)
+    # if explicitly provided, ensure it is permitted (admin allow any, otherwise self-user reference only)
+    if header is not None:
+        if request.user is None:
+            header = "public"
+        else:
+            if not is_admin(request):
+                # override disallowed writing to other location
+                # otherwise, up to admin to have writen something sensible
+                header = "user-" + str(request.user.id)
+    else:
+        if request.user is None:
+            header = "public"
+        else:
+            header = "user-" + str(request.user.id)
+    request.headers["X-WPS-Output-Context"] = header
     return request

--- a/birdhouse/components/weaver/config/magpie/config.yml.template
+++ b/birdhouse/components/weaver/config/magpie/config.yml.template
@@ -10,6 +10,7 @@ providers:
     c4i: false
     type: api   # FIXME: 'ades' when https://github.com/Ouranosinc/Magpie/issues/360 implemented
     sync_type: api
+    # hook locations should be relative to mounted Twitcher location as they are run within that container
     # see following for hooks details:
     # - https://github.com/Ouranosinc/Magpie/blob/master/config/providers.cfg
     # - https://pavics-magpie.readthedocs.io/en/latest/configuration.html#service-hooks
@@ -21,15 +22,15 @@ providers:
       - type: request
         path: "/providers/[\\w_-]+/processes/[\\w_-]+/jobs"
         method: POST
-        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+        target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:add_x_wps_output_context
       - type: request
         path: "/processes/[\\w_-]+/jobs"
         method: POST
-        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+        target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:add_x_wps_output_context
       - type: request
         path: "/jobs"
         method: POST
-        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+        target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:add_x_wps_output_context
 
   # FIXME: remove when https://github.com/Ouranosinc/Magpie/issues/360 implemented, see 'default.env'
   ${WEAVER_WPS_NAME}:

--- a/birdhouse/components/weaver/config/magpie/config.yml.template
+++ b/birdhouse/components/weaver/config/magpie/config.yml.template
@@ -10,6 +10,26 @@ providers:
     c4i: false
     type: api   # FIXME: 'ades' when https://github.com/Ouranosinc/Magpie/issues/360 implemented
     sync_type: api
+    # see following for hooks details:
+    # - https://github.com/Ouranosinc/Magpie/blob/master/config/providers.cfg
+    # - https://pavics-magpie.readthedocs.io/en/latest/configuration.html#service-hooks
+    hooks:
+      # when a job is created in weaver, apply the header that will nest output results under user's context directory
+      # see also:
+      # - https://pavics-weaver.readthedocs.io/en/latest/processes.html?highlight=x-wps-output-context#outputs-location
+      # each path below are equivalents, but with more or less specific reference to the requested service/process
+      - type: request
+        path: "/providers/[\\w_-]+/processes/[\\w_-]+/jobs"
+        method: POST
+        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+      - type: request
+        path: "/processes/[\\w_-]+/jobs"
+        method: POST
+        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+      - type: request
+        path: "/jobs"
+        method: POST
+        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
 
   # FIXME: remove when https://github.com/Ouranosinc/Magpie/issues/360 implemented, see 'default.env'
   ${WEAVER_WPS_NAME}:

--- a/birdhouse/components/weaver/config/magpie/weaver_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/weaver_hooks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-These hooks will be running within Twitcher, using MagpieAdapter context.
+These hooks will be running within Twitcher, using MagpieAdapter context, applied for Weaver requests.
 
 The code below can make use of any package that is installed by Magpie/Twitcher.
 """

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -37,7 +37,7 @@ services:
     volumes:
       # NOTE: MagpieAdapter hooks are defined within Magpie config, but it is actually Twitcher proxy that runs them
       - ./components/weaver/config/magpie/config.yml:/opt/birdhouse/src/magpie/config.yml
-      - ./components/weaver/config/magpie/adapter_hooks.py:/opt/birdhouse/src/magpie/adapter_hooks.py
+      - ./components/weaver/config/magpie/weaver_hooks.py:/opt/birdhouse/src/magpie/hooks/weaver_hooks.py
 
   # Image 'weaver' is the API side of the application
   weaver:

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -30,6 +30,15 @@ services:
       - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/permissions/weaver-permissions.cfg:ro
       - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/providers/weaver-provider.cfg:ro
 
+  # extend twitcher with MagpieAdapter hooks employed for weaver proxied requests
+  twitcher:
+    environment:
+      MAGPIE_CONFIG_PATH: /opt/birdhouse/src/magpie/config.yml
+    volumes:
+      # NOTE: MagpieAdapter hooks are defined within Magpie config, but it is actually Twitcher proxy that runs them
+      - ./components/weaver/config/magpie/config.yml:/opt/birdhouse/src/magpie/config.yml
+      - ./components/weaver/config/magpie/adapter_hooks.py:/opt/birdhouse/src/magpie/adapter_hooks.py
+
   # Image 'weaver' is the API side of the application
   weaver:
     container_name: ${WEAVER_MANAGER_NAME}

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -22,7 +22,7 @@ export GEOSERVER_IMAGE="pavics/geoserver:2.19.0-kartoza-build20210329"
 export BASH_IMAGE="bash:5.1.4"
 
 # Tag version that will be used to update Magpie API, Magpie CLI, and matching Twitcher with Magpie Adapter
-export MAGPIE_VERSION=3.21.0
+export MAGPIE_VERSION=3.25.0
 
 # Root directory under which all data persistence should be nested under
 export DATA_PERSIST_ROOT="/data"


### PR DESCRIPTION
## Overview

Prepare magpie/twitcher/weaver requests hooks for WPS outputs in user workspace directory 

## Changes

**Non-breaking changes**
- When a job is run on weaver while being logged in, the output results will be nested under a user-workspace directory rather than at the root of WPS outputs. 

**Breaking changes**
- n/a

## Related Issue / Discussion

- Depends on: 
   - https://github.com/Ouranosinc/Magpie/pull/517  (Magpie [3.25.0](https://github.com/Ouranosinc/Magpie/tree/3.25.0))
   - https://github.com/bird-house/twitcher/pull/114  (Twitcher [0.7.0](https://github.com/bird-house/twitcher/tree/v0.7.0))
