### PR TITLE
Auto user permissions creation over its deployed process

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.13
+current_version = 1.19.0
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ ubuntu-bionic-18.04-cloudimg-console.log
 
 ## vim temp files
 *.swp
+
+## Python temp files
+**/__pycache__
+**/*.py[cod]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,22 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+
+- Magpie/Twitcher: update `magpie` service
+  from [3.21.0](https://github.com/Ouranosinc/Magpie/tree/3.21.0)
+  to [3.25.0](https://github.com/Ouranosinc/Magpie/tree/3.25.0) and 
+  bundled `twitcher` from [0.6.2](https://github.com/bird-house/twitcher/tree/v0.6.2)
+  to [0.7.0](https://github.com/bird-house/twitcher/tree/v0.7.0).
+  
+  - Adds [Service Hooks](https://pavics-magpie.readthedocs.io/en/latest/configuration.html#service-hooks) allowing 
+    Twitcher to apply HTTP pre-request/post-response modifications to requested services and resources in accordance
+    to `MagpieAdapter` implementation and using plugin Python scripts when matched against specific request parameters.
+
+  - Using *Service Hooks*, inject ``X-WPS-Output-Context`` header in Weaver job submission requests through the proxied
+    request by Twitcher and `MagpieAdapter`. This header contains the user ID that indicates to Weaver were to store 
+    job output results, allowing to save them in the corresponding user's workspace directory under `wpsoutputs` path.
+
 
 [1.18.12](https://github.com/bird-house/birdhouse-deploy/tree/1.18.12) (2022-05-05)
 ------------------------------------------------------------------------------------------------------------------
@@ -3314,4 +3329,3 @@ Prior Versions
 All versions prior to [1.7.0](https://github.com/bird-house/birdhouse-deploy/tree/1.7.0) were not officially tagged.
 Is it strongly recommended employing later versions to ensure better traceability of changes that could impact behavior
 and potential issues on new server instances. 
-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,10 +29,19 @@
   - Using *Service Hooks*, inject ``X-WPS-Output-Context`` header in Weaver job submission requests through the proxied
     request by Twitcher and `MagpieAdapter`. This header contains the user ID that indicates to Weaver were to store 
     job output results, allowing to save them in the corresponding user's workspace directory under `wpsoutputs` path.
+    More details found in PR https://github.com/bird-house/birdhouse-deploy/pull/244.
 
   - Using *Service Hooks*, filter processes returned by Weaver in JSON response from ``/processes`` endpoint using
     respective permissions applied onto each ``/processes/{processID}`` for the requesting user. Users will only be able
     to see processes for which they have read access to retrieve the process description.
+    More details found in PR https://github.com/bird-house/birdhouse-deploy/pull/245.
+
+  - Using *Service Hooks*, automatically apply permissions for the user that successfully deployed a Weaver process 
+    using ``POST /processes`` request, granting it direct access to this process during process listing, process 
+    description request and for submitting job execution of this process.
+    Only this user deploying the process will have access to it until further permissions are added in Magpie to share
+    or publish it with other users, groups and/or publicly. The user must have the necessary permission to deploy a new
+    process in the first place. More details found in PR https://github.com/bird-house/birdhouse-deploy/pull/247.
 
 [1.18.12](https://github.com/bird-house/birdhouse-deploy/tree/1.18.12) (2022-05-05)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 
 - Magpie/Twitcher: update `magpie` service
   from [3.21.0](https://github.com/Ouranosinc/Magpie/tree/3.21.0)
-  to [3.25.0](https://github.com/Ouranosinc/Magpie/tree/3.25.0) and 
+  to [3.26.0](https://github.com/Ouranosinc/Magpie/tree/3.26.0) and
   bundled `twitcher` from [0.6.2](https://github.com/bird-house/twitcher/tree/v0.6.2)
   to [0.7.0](https://github.com/bird-house/twitcher/tree/v0.7.0).
   
@@ -30,6 +30,9 @@
     request by Twitcher and `MagpieAdapter`. This header contains the user ID that indicates to Weaver were to store 
     job output results, allowing to save them in the corresponding user's workspace directory under `wpsoutputs` path.
 
+  - Using *Service Hooks*, filter processes returned by Weaver in JSON response from ``/processes`` endpoint using
+    respective permissions applied onto each ``/processes/{processID}`` for the requesting user. Users will only be able
+    to see processes for which they have read access to retrieve the process description.
 
 [1.18.12](https://github.com/bird-house/birdhouse-deploy/tree/1.18.12) (2022-05-05)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.19.0](https://github.com/bird-house/birdhouse-deploy/tree/1.19.0) (2022-06-08)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 
 - Magpie/Twitcher: update `magpie` service

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.13.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.19.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.13...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.19.0...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.13-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.19.0-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.13
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.19.0
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/components/weaver/config/magpie/adapter_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/adapter_hooks.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyramid.request import Request
+
+    from magpie.typedefs import ServiceConfigItem
+
+
+def add_x_wps_output_context(request, service):
+    # type: (Request, ServiceConfigItem) -> Request
+    if "application/json" in request.content_type:
+        body = request.json  # JSON generated from body, cannot override directly
+        # following for testing purposes only
+        body["hooks"] = len(service["hooks"])
+        body["hook"] = "add_x_wps_output_context"
+        request.body = json.dumps(body).encode()
+    if request.user is not None:
+        request.headers["X-WPS-Output-Context"] = "user-" + str(request.user.id)
+    return request

--- a/birdhouse/components/weaver/config/magpie/adapter_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/adapter_hooks.py
@@ -1,22 +1,45 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import json
+"""
+These hooks will be running within Twitcher, using MagpieAdapter context.
+
+The code below can make use of any package that is installed by Magpie/Twitcher.
+"""
+
 from typing import TYPE_CHECKING
+
+from magpie.constants import get_constant
+from magpie.utils import get_header
 
 if TYPE_CHECKING:
     from pyramid.request import Request
 
-    from magpie.typedefs import ServiceConfigItem
+
+def is_admin(request):
+    # type: (Request) -> bool
+    admin_group = get_constant("MAGPIE_ADMIN_GROUP", settings_container=request)
+    return admin_group in [group.group_name for group in request.user.groups]
 
 
-def add_x_wps_output_context(request, service):
-    # type: (Request, ServiceConfigItem) -> Request
-    if "application/json" in request.content_type:
-        body = request.json  # JSON generated from body, cannot override directly
-        # following for testing purposes only
-        body["hooks"] = len(service["hooks"])
-        body["hook"] = "add_x_wps_output_context"
-        request.body = json.dumps(body).encode()
-    if request.user is not None:
-        request.headers["X-WPS-Output-Context"] = "user-" + str(request.user.id)
+def add_x_wps_output_context(request):
+    # type: (Request) -> Request
+    """
+    Apply the ``X-WPS-Output-Context`` for saving outputs in the user-context WPS-outputs directory.
+    """
+    header = get_header("X-WPS-Output-Context", request.headers)
+    # if explicitly provided, ensure it is permitted (admin allow any, otherwise self-user reference only)
+    if header is not None:
+        if request.user is None:
+            header = "public"
+        else:
+            if not is_admin(request):
+                # override disallowed writing to other location
+                # otherwise, up to admin to have writen something sensible
+                header = "user-" + str(request.user.id)
+    else:
+        if request.user is None:
+            header = "public"
+        else:
+            header = "user-" + str(request.user.id)
+    request.headers["X-WPS-Output-Context"] = header
     return request

--- a/birdhouse/components/weaver/config/magpie/config.yml.template
+++ b/birdhouse/components/weaver/config/magpie/config.yml.template
@@ -91,9 +91,10 @@ permissions:
     action: create
 
   # Process deployment (write) and listing (read)
+  # use 'read-match' to allow only listing, and not describe underlying processes (require 'read' on them individually)
   - service: ${WEAVER_MANAGER_NAME}
     resource: /processes    # GET is processes listing, POST is deploy: only allow view by anonymous
-    permission: read        # under '/processes/...', JSON 'DescribeProcess', POST job submit, GET results, etc.
+    permission: read-match  # under '/processes/...', JSON 'DescribeProcess', POST job submit, GET results, etc.
     group: anonymous
     action: create
 

--- a/birdhouse/components/weaver/config/magpie/config.yml.template
+++ b/birdhouse/components/weaver/config/magpie/config.yml.template
@@ -31,6 +31,10 @@ providers:
         path: "/jobs"
         method: POST
         target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:add_x_wps_output_context
+      - type: response
+        path: "/processes"
+        method: GET
+        target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:filter_allowed_processes
 
   # FIXME: remove when https://github.com/Ouranosinc/Magpie/issues/360 implemented, see 'default.env'
   ${WEAVER_WPS_NAME}:

--- a/birdhouse/components/weaver/config/magpie/config.yml.template
+++ b/birdhouse/components/weaver/config/magpie/config.yml.template
@@ -10,6 +10,7 @@ providers:
     c4i: false
     type: api   # FIXME: 'ades' when https://github.com/Ouranosinc/Magpie/issues/360 implemented
     sync_type: api
+    # hook locations should be relative to mounted Twitcher location as they are run within that container
     # see following for hooks details:
     # - https://github.com/Ouranosinc/Magpie/blob/master/config/providers.cfg
     # - https://pavics-magpie.readthedocs.io/en/latest/configuration.html#service-hooks
@@ -21,15 +22,15 @@ providers:
       - type: request
         path: "/providers/[\\w_-]+/processes/[\\w_-]+/jobs"
         method: POST
-        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+        target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:add_x_wps_output_context
       - type: request
         path: "/processes/[\\w_-]+/jobs"
         method: POST
-        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+        target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:add_x_wps_output_context
       - type: request
         path: "/jobs"
         method: POST
-        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+        target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:add_x_wps_output_context
 
   # FIXME: remove when https://github.com/Ouranosinc/Magpie/issues/360 implemented, see 'default.env'
   ${WEAVER_WPS_NAME}:

--- a/birdhouse/components/weaver/config/magpie/config.yml.template
+++ b/birdhouse/components/weaver/config/magpie/config.yml.template
@@ -10,6 +10,26 @@ providers:
     c4i: false
     type: api   # FIXME: 'ades' when https://github.com/Ouranosinc/Magpie/issues/360 implemented
     sync_type: api
+    # see following for hooks details:
+    # - https://github.com/Ouranosinc/Magpie/blob/master/config/providers.cfg
+    # - https://pavics-magpie.readthedocs.io/en/latest/configuration.html#service-hooks
+    hooks:
+      # when a job is created in weaver, apply the header that will nest output results under user's context directory
+      # see also:
+      # - https://pavics-weaver.readthedocs.io/en/latest/processes.html?highlight=x-wps-output-context#outputs-location
+      # each path below are equivalents, but with more or less specific reference to the requested service/process
+      - type: request
+        path: "/providers/[\\w_-]+/processes/[\\w_-]+/jobs"
+        method: POST
+        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+      - type: request
+        path: "/processes/[\\w_-]+/jobs"
+        method: POST
+        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
+      - type: request
+        path: "/jobs"
+        method: POST
+        target: /opt/local/src/magpie/hooks/adapter_hooks.py:add_x_wps_output_context
 
   # FIXME: remove when https://github.com/Ouranosinc/Magpie/issues/360 implemented, see 'default.env'
   ${WEAVER_WPS_NAME}:

--- a/birdhouse/components/weaver/config/magpie/config.yml.template
+++ b/birdhouse/components/weaver/config/magpie/config.yml.template
@@ -35,6 +35,10 @@ providers:
         path: "/processes"
         method: GET
         target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:filter_allowed_processes
+      - type: response
+        path: "/processes"
+        method: POST
+        target: /opt/birdhouse/src/magpie/hooks/weaver_hooks.py:allow_user_deployed_processes
 
   # FIXME: remove when https://github.com/Ouranosinc/Magpie/issues/360 implemented, see 'default.env'
   ${WEAVER_WPS_NAME}:

--- a/birdhouse/components/weaver/config/magpie/weaver_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/weaver_hooks.py
@@ -72,7 +72,7 @@ def filter_allowed_processes(response, context):
             children = ru.get_resource_children(context.resource, response.request.db, limit_depth=2)
             proc_res = None
             for res in children.values():
-                if res["node"] == "processes":
+                if res["node"].resource_name == "processes":
                     # if nothing under 'processes' resource, then guarantee no permissions, done check
                     if not res["children"]:
                         return response
@@ -83,11 +83,11 @@ def filter_allowed_processes(response, context):
 
             allowed_processes = []
             known_processes = proc_res["children"].values()
-            known_processes = {res["node"].resource.resource_name: res for res in known_processes}
+            known_processes = {res["node"].resource_name: res for res in known_processes}
             for proc_name in processes:
                 if proc_name not in known_processes:
                     continue  # do not bother checking missing resource
-                child_proc = known_processes[proc_name]
+                child_proc = known_processes[proc_name]["node"]
                 perms = context.service.effective_permissions(response.request.user, child_proc, [Permission.READ])
                 if perms[0].access == Access.ALLOW:
                     proc = processes[proc_name]

--- a/birdhouse/components/weaver/config/magpie/weaver_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/weaver_hooks.py
@@ -53,7 +53,7 @@ def add_x_wps_output_context(request):
         else:
             if not is_admin(request):
                 # override disallowed writing to other location
-                # otherwise, up to admin to have writen something sensible
+                # otherwise, up to admin to have written something sensible
                 header = "user-" + str(request.user.id)
     else:
         if request.user is None:

--- a/birdhouse/components/weaver/config/magpie/weaver_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/weaver_hooks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-These hooks will be running within Twitcher, using MagpieAdapter context.
+These hooks will be running within Twitcher, using MagpieAdapter context, applied for Weaver requests.
 
 The code below can make use of any package that is installed by Magpie/Twitcher.
 """

--- a/birdhouse/components/weaver/config/magpie/weaver_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/weaver_hooks.py
@@ -6,13 +6,19 @@ These hooks will be running within Twitcher, using MagpieAdapter context, applie
 The code below can make use of any package that is installed by Magpie/Twitcher.
 """
 
+import json
 from typing import TYPE_CHECKING
 
+from magpie.api.management.resource import resource_utils as ru
 from magpie.constants import get_constant
+from magpie.permissions import Access, Permission
 from magpie.utils import get_header
 
 if TYPE_CHECKING:
     from pyramid.request import Request
+    from pyramid.response import Response
+
+    from magpie.adapter import HookContext
 
 
 def is_admin(request):
@@ -43,3 +49,60 @@ def add_x_wps_output_context(request):
             header = "user-" + str(request.user.id)
     request.headers["X-WPS-Output-Context"] = header
     return request
+
+
+def filter_allowed_processes(response, context):
+    # type: (Response, HookContext) -> Response
+    """
+    Filter processes returned by Weaver response according to allowed resources by user.
+    """
+    if "application/json" in response.content_type:
+        body = response.json
+        if "processes" in body:
+            if is_admin(response.request):  # don't waste time checking permissions, full access anyway
+                return response
+
+            # depending on 'detail' query, processes can be returned as list of IDs or nested JSON summaries
+            processes = {
+                proc if isinstance(proc, str) else proc.get("id"): proc
+                for proc in body["processes"]
+            }
+
+            # only need 2 first levels ('processes' and each process 'id' under it)
+            children = ru.get_resource_children(context.resource, response.request.db, limit_depth=2)
+            proc_res = None
+            for res in children.values():
+                if res["node"] == "processes":
+                    # if nothing under 'processes' resource, then guarantee no permissions, done check
+                    if not res["children"]:
+                        return response
+                    proc_res = res
+                    break
+            if not proc_res:
+                return response  # 'processes' itself does not exist, no permissions possible and done check
+
+            allowed_processes = []
+            known_processes = proc_res["children"].values()
+            known_processes = {res["node"].resource.resource_name: res for res in known_processes}
+            for proc_name in processes:
+                if proc_name not in known_processes:
+                    continue  # do not bother checking missing resource
+                child_proc = known_processes[proc_name]
+                perms = context.service.effective_permissions(response.request.user, child_proc, [Permission.READ])
+                if perms[0].access == Access.ALLOW:
+                    proc = processes[proc_name]
+                    allowed_processes.append(proc)
+
+            # override collected and permitted processes access by user
+            body["processes"] = allowed_processes
+
+            # WARNING:
+            #  JSON generated from 'body' attribute cannot be overridden directly (computed inline).
+            #  Also, since we override, must set any Content header accordingly with modifications.
+            data = json.dumps(body).encode("UTF-8")
+            response.body = data
+            c_len = len(data)
+            response.content_length = c_len
+            response.headers["Content-Length"] = str(c_len)
+
+    return response

--- a/birdhouse/components/weaver/config/magpie/weaver_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/weaver_hooks.py
@@ -58,6 +58,53 @@ def filter_allowed_processes(response, context):
     # type: (Response, HookContext) -> Response
     """
     Filter processes returned by Weaver response according to allowed resources by user.
+
+    Following are sample (clipped) JSON body that can be expected from Weaver (or any OGC API - Processes).
+
+    Using ``GET https://<weaver.url>/processes``
+
+    .. code-block:: json
+        :caption: Detailed process listing from Weaver (other fields than 'processes' are removed for concise example).
+
+        {
+          "processes": [
+            {
+              "id": "ColibriFlyingpigeon_SubsetBbox",
+              "title": "ColibriFlyingpigeon_SubsetBbox",
+              "mutable": true,
+              "keywords": [
+                "application"
+              ],
+              "metadata": [],
+              "jobControlOptions": [
+                "async-execute"
+              ],
+              "outputTransmission": [
+                "reference",
+                "value"
+              ],
+              "processDescriptionURL": "https://<weaver.url>/processes/ColibriFlyingpigeon_SubsetBbox",
+              "processEndpointWPS1": "https://<weaver.url>/ows/wps",
+              "executeEndpoint": "https://<weaver.url>/processes/ColibriFlyingpigeon_SubsetBbox/jobs"
+            }
+          ]
+        }
+
+    Using ``GET https://<weaver.url>/processes?detail=false``
+
+    .. code-block:: json
+        :caption: Simple process listing from Weaver (other fields than 'processes' are removed for concise example).
+
+        {
+          "description": "Listing of available processes successful.",
+          "processes": [
+            "CatFile",
+            "ColibriFlyingpigeon_SubsetBbox",
+          ],
+          "page": 0,
+          "total": 2
+        }
+
     """
     if "application/json" in response.content_type:
         body = response.json

--- a/birdhouse/components/weaver/config/magpie/weaver_hooks.py
+++ b/birdhouse/components/weaver/config/magpie/weaver_hooks.py
@@ -4,6 +4,10 @@
 These hooks will be running within Twitcher, using MagpieAdapter context, applied for Weaver requests.
 
 The code below can make use of any package that is installed by Magpie/Twitcher.
+
+.. seealso::
+    Documentation about Magpie/Twitcher request/response hooks is available here:
+    https://pavics-magpie.readthedocs.io/en/latest/configuration.html#service-hooks
 """
 
 import json

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -37,7 +37,7 @@ services:
     volumes:
       # NOTE: MagpieAdapter hooks are defined within Magpie config, but it is actually Twitcher proxy that runs them
       - ./components/weaver/config/magpie/config.yml:/opt/birdhouse/src/magpie/config.yml
-      - ./components/weaver/config/magpie/adapter_hooks.py:/opt/birdhouse/src/magpie/adapter_hooks.py
+      - ./components/weaver/config/magpie/weaver_hooks.py:/opt/birdhouse/src/magpie/hooks/weaver_hooks.py
 
   # Image 'weaver' is the API side of the application
   weaver:

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -30,6 +30,15 @@ services:
       - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/permissions/weaver-permissions.cfg:ro
       - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/providers/weaver-provider.cfg:ro
 
+  # extend twitcher with MagpieAdapter hooks employed for weaver proxied requests
+  twitcher:
+    environment:
+      MAGPIE_CONFIG_PATH: /opt/birdhouse/src/magpie/config.yml
+    volumes:
+      # NOTE: MagpieAdapter hooks are defined within Magpie config, but it is actually Twitcher proxy that runs them
+      - ./components/weaver/config/magpie/config.yml:/opt/birdhouse/src/magpie/config.yml
+      - ./components/weaver/config/magpie/adapter_hooks.py:/opt/birdhouse/src/magpie/adapter_hooks.py
+
   # Image 'weaver' is the API side of the application
   weaver:
     container_name: ${WEAVER_MANAGER_NAME}

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -23,21 +23,19 @@ services:
   magpie:
     volumes:
       # NOTE:
-      #   Although file use the "config.yml" format, it is very important to pass it as independent/duplicate reference
-      #   provider/permissions ".cfg" files. This is because Magpie will not parse multiple "config.yml" files
-      #   additively with other component's ".cfg" files, as "config.yml" are intended for unique-combined definitions.
-      #   Data structure within "config.yml" is the same as within the respective sections in typical ".cfg" files.
-      - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/permissions/weaver-permissions.cfg:ro
-      - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/providers/weaver-provider.cfg:ro
+      #   Although file uses the "config.yml" format, it is very important to pass it as independent/duplicate reference
+      #   provider/permissions config files. This is because 'MAGPIE_CONFIG_PATH' is not used to allow parsing multiple
+      #   config files for each extendable service, using loading of all configuration files found in mount directories.
+      - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/permissions/weaver-permissions.yml:ro
+      - ./components/weaver/config/magpie/config.yml:/opt/local/src/magpie/config/providers/weaver-provider.yml:ro
 
   # extend twitcher with MagpieAdapter hooks employed for weaver proxied requests
   twitcher:
-    environment:
-      MAGPIE_CONFIG_PATH: /opt/birdhouse/src/magpie/config.yml
     volumes:
       # NOTE: MagpieAdapter hooks are defined within Magpie config, but it is actually Twitcher proxy that runs them
-      - ./components/weaver/config/magpie/config.yml:/opt/birdhouse/src/magpie/config.yml
-      - ./components/weaver/config/magpie/weaver_hooks.py:/opt/birdhouse/src/magpie/hooks/weaver_hooks.py
+      # target mount location depends on main docker-compose 'MAGPIE_PROVIDERS_CONFIG_PATH' environment variable
+      - ./components/weaver/config/magpie/config.yml:/opt/birdhouse/src/magpie/config/weaver-config.yml:ro
+      - ./components/weaver/config/magpie/weaver_hooks.py:/opt/birdhouse/src/magpie/hooks/weaver_hooks.py:ro
 
   # Image 'weaver' is the API side of the application
   weaver:

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -22,7 +22,7 @@ export GEOSERVER_IMAGE="pavics/geoserver:2.19.0-kartoza-build20210329"
 export BASH_IMAGE="bash:5.1.4"
 
 # Tag version that will be used to update Magpie API, Magpie CLI, and matching Twitcher with Magpie Adapter
-export MAGPIE_VERSION=3.25.0
+export MAGPIE_VERSION=3.26.0
 
 # Root directory under which all data persistence should be nested under
 export DATA_PERSIST_ROOT="/data"

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -22,7 +22,7 @@ export GEOSERVER_IMAGE="pavics/geoserver:2.19.0-kartoza-build20210329"
 export BASH_IMAGE="bash:5.1.4"
 
 # Tag version that will be used to update Magpie API, Magpie CLI, and matching Twitcher with Magpie Adapter
-export MAGPIE_VERSION=3.21.0
+export MAGPIE_VERSION=3.25.0
 
 # Root directory under which all data persistence should be nested under
 export DATA_PERSIST_ROOT="/data"

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -333,7 +333,8 @@ services:
     environment:
       TWITCHER_PROTECTED_URL: https://${PAVICS_FQDN_PUBLIC}${TWITCHER_PROTECTED_PATH}
       # target directories to allow loading multiple config files of corresponding category
-      # each compose override should volume mount its files in the matching directories
+      # each compose override should volume mount its files inside the matching directories
+      # (note: DO NOT use 'MAGPIE_CONFIG_PATH' that would disable multi-config loading capability)
       MAGPIE_PROVIDERS_CONFIG_PATH: "/opt/local/src/magpie/config/providers"
       MAGPIE_PERMISSIONS_CONFIG_PATH: "/opt/local/src/magpie/config/permissions"
       MAGPIE_POSTGRES_HOST: postgres-magpie
@@ -358,6 +359,14 @@ services:
     container_name: twitcher
     ports:
       - "8000:8000"
+    environment:
+      # target directories to allow loading multiple config files of corresponding category
+      # each compose override should volume mount its files inside the below directory
+      # (note: DO NOT use 'MAGPIE_CONFIG_PATH' that would disable multi-config loading capability)
+      # Only 'providers' sections are used to employ 'request/response hooks' with 'MagpieAdapter'.
+      # Hooks are defined within Magpie config, but it is actually Twitcher proxy that runs them.
+      # Other Magpie components are unknown and ignored by Twitcher itself.
+      MAGPIE_PROVIDERS_CONFIG_PATH: "/opt/birdhouse/src/magpie/config"
     env_file:
       - ./config/postgres-magpie/credentials.env
     depends_on:


### PR DESCRIPTION
When a process is deployed on Weaver, the user that deployed it (provided they had permission to do so), will automatically receive the necessary permissions to obtain access to its description and execution of jobs with it.

The process will be visible only by the deploying user (and admins) until it gets shared/published with other users/groups with the appropriate permissions applied in Magpie.

## Changes

**Non-breaking changes**
- Adds Magpie response hook that will create necessary permissions for user onto its deployed Weaver process.

**Breaking changes**
- n/a

**Note**: only commits after https://github.com/bird-house/birdhouse-deploy/pull/247/commits/e661ef269bdeba5d8a503bfbc5727b8c8082964e can be used to see only the diff of *this* PR omitting other dependencies.

## Related Issue / Discussion

- Resolves [DAC-206 - *user private process deployment*](https://crim-ca.atlassian.net/browse/DAC-206)

## Additional Information

- [ ] Depends on #244 
- [ ] Depends on #245
- [ ] Depends on https://github.com/crim-ca/weaver/pull/442
  (only for using the CLI below, not impacting the stack itself)


### Results / Demonstration

Using the Weaver CLI in combination of https://github.com/Ouranosinc/requests-magpie/, following command is sent and received:

```shell
weaver deploy \
  -u http://localhost:8000/ows/proxy/weaver \
  -p test-report \
  --cwl https://raw.githubusercontent.com/crim-ca/weaver/master/docs/examples/docker-python-script-report.cwl \
  --auth-handler requests_magpie.MagpieAuth \
  --auth-url http://localhost:2001 \
  --auth-username authtest \
  --auth-password authtestauthtest

[2022-06-06 16:21:35] WARNING  [weaver.utils] No settings container provided by [weaver.utils.wrapped], request options might not be applied as expected.
[2022-06-06 16:21:35] WARNING  [weaver.utils] No settings container provided by [weaver.utils.wrapped], request options might not be applied as expected.
[2022-06-06 16:21:35] WARNING  [weaver.utils] No settings container provided by [weaver.utils.wrapped], request options might not be applied as expected.
Resolved '/tmp/tmp5qbm9jep/package' to 'file:///tmp/tmp5qbm9jep/package'
{
  "description": "Process successfully deployed.",
  "processSummary": {
    "id": "test-report",
    "mutable": true,
    "keywords": [
      "application"
    ],
    "metadata": [],
    "jobControlOptions": [
      "async-execute",
      "sync-execute"
    ],
    "outputTransmission": [
      "reference",
      "value"
    ],
    "processDescriptionURL": "http://localhost:4002/processes/test-report",
    "executeEndpoint": "http://localhost:4002/processes/test-report/jobs"
  },
  "deploymentDone": true
}
```

> *note:*
    http://localhost:8000/ows/proxy/weaver is a Twitcher instance running with configured Magpie on http://localhost:2001 and Weaver defined as a service behind them.

Before execution, the following is shown in Magpie. These definitions are similar to current birdhouse stack when Weaver is enabled to be registered with minimal permissions. Deploy permission (write) is added to the test user using `match` modifier (contrary to `recursive`) such that they can POST (i.e.: deploy) on that specific endpoint, but cannot execute *all* underlying process/jobs.

![image](https://user-images.githubusercontent.com/19194484/172252449-f061b90a-9dd3-4494-ad9f-526b2457e86f.png)

After the execution of the CLI command, the following is obtained. This grants access to the user for execution and un-deployment of the new process, but still cannot modify/execute other processes they do not "own".

![image](https://user-images.githubusercontent.com/19194484/172252629-41188e2f-28dd-44a3-987c-fb332473fa48.png)

Logs display the valid creation:

```log
2022-06-06 16:44:19,543 INFO  [TWITCHER|magpie.adapter.magpieowssecurity:245][ThreadPoolExecutor-0_0] User <User: name=authtest id=17089> resolved with allowed 'write' access to [/ows/proxy/weaver/processes]
2022-06-06 16:44:19,544 INFO  [TWITCHER:57][ThreadPoolExecutor-0_0] Using adapter: '<class 'magpie.adapter.MagpieAdapter'>'
2022-06-06 16:44:19,546 DEBUG [TWITCHER:79][ThreadPoolExecutor-0_0] url = http://localhost:4002/processes
2022-06-06 16:44:19,712 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Using settings from local thread.
2022-06-06 16:44:19,712 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Constant alternate search: magpie.providers_hooks_path
2022-06-06 16:44:19,712 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Constant found in definitions with: MAGPIE_PROVIDERS_HOOKS_PATH
2022-06-06 16:44:19,715 DEBUG [TWITCHER|magpie.adapter:316][ThreadPoolExecutor-0_0] Hook matched response (POST /processes) [/home/francis/dev/daccs/birdhouse-deploy/birdhouse/components/weaver/config/magpie/weaver_hooks.py:allow_user_deployed_processes]
2022-06-06 16:44:19,716 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Constant alternate search: magpie.admin_group
2022-06-06 16:44:19,716 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Constant found in definitions with: MAGPIE_ADMIN_GROUP
[2022-06-06 16:44:26 -0400] [719671] [CRITICAL] WORKER TIMEOUT (pid:719703)
[2022-06-06 16:44:26 -0400] [719703] [INFO] Worker exiting (pid: 719703)
Exiting 1 (-v to see traceback)
2022-06-06 16:44:42,619 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Using settings from local thread.
2022-06-06 16:44:42,620 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Constant alternate search: magpie.anonymous_user
2022-06-06 16:44:42,620 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Constant found in definitions with: MAGPIE_ANONYMOUS_USER
2022-06-06 16:44:42,621 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Using settings from local thread.
2022-06-06 16:44:43,588 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Using settings from local thread.
2022-06-06 16:44:43,588 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Constant alternate search: magpie.anonymous_user
2022-06-06 16:44:43,589 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Constant found in definitions with: MAGPIE_ANONYMOUS_USER
2022-06-06 16:44:43,589 DEBUG [magpie.utils:163][ThreadPoolExecutor-0_0] Using settings from local thread.
2022-06-06 16:45:02,248 INFO  [birdhouse-weaver-hooks:257][ThreadPoolExecutor-0_0] Successful creation of permissions for user [authtest] to access deployed process [test-report] in Weaver.
```


