### PR TITLE
deploy-data: new env var DEPLOY_DATA_RSYNC_USER_GRP to avoid running cronjobs as root

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.12
+current_version = 1.18.13
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.18.13](https://github.com/bird-house/birdhouse-deploy/tree/1.18.13) (2022-06-07)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 
 - deploy-data: new env var DEPLOY_DATA_RSYNC_USER_GRP to avoid running cronjobs as root

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,39 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+
+- deploy-data: new env var DEPLOY_RSYNC_USER_GRP to follow security best practices
+
+  When `deploy-data` is used by the `scheduler` component, it is run as
+  `root`.  This new env var will force the rsync process to run as a regular user to
+  follow security best practice to avoid running as root when not needed.
+
+  Note that the `git checkout` step done by `deploy-data` is still run as root.
+  This is because `deploy-data` is currently still run as root so it can
+  execute `docker` commands (ex: spawning the `rsync` command above in its own
+  docker container).
+
+  To fix this limitation, the regular user inside the `deploy-data` container
+  need to have docker access inside the container and outside on the host at
+  the same time.  If we make that regular user configurable so the script
+  `deploy-data` is generic and can work for any organisations, this is tricky
+  for the moment so will have to be handle in another PR.
+
+  So for the moment we have not achieved full non-root user in cronjobs
+  launched by the `scheduler` compoment but the most important part, the part
+  that perform the actual job (rsync or execute custom command using an
+  external docker container) is running as non-root.
+
+  See PR https://github.com/bird-house/birdhouse-deploy-ouranos/pull/18 that
+  make use of this new env var.
+
+  When `deploy-data` is invoking an external script that itself spawn a new
+  `docker run`, then it is up to this external script to ensure the proper
+  non-root user is used by `docker run`.
+  See PR https://github.com/Ouranosinc/pavics-vdb/pull/50 that handle that
+  case.
+
 
 [1.18.12](https://github.com/bird-house/birdhouse-deploy/tree/1.18.12) (2022-05-05)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 
 ## Changes:
 
-- deploy-data: new env var DEPLOY_RSYNC_USER_GRP to follow security best practices
+- deploy-data: new env var DEPLOY_DATA_RSYNC_USER_GRP to avoid running cronjobs as root
 
   When `deploy-data` is used by the `scheduler` component, it is run as
   `root`.  This new env var will force the rsync process to run as a regular user to

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.12.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.18.13.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.12...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.18.13...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.12-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.18.13-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.12
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.18.13
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/deployment/deploy-data
+++ b/birdhouse/deployment/deploy-data
@@ -14,6 +14,10 @@
 # very few install dependencies (only need docker and git installed locally)
 # so it can runs inside very minimalistic image (the 'docker' Docker image).
 #
+# Setting environment variable DEPLOY_DATA_RSYNC_USER_GRP='user:group' to
+# specify the user to run inside the rsync docker container.  Remember to give
+# that user write permission on the rsync target on disk.
+#
 # Setting environment variable DEPLOY_DATA_LOGFILE='/path/to/logfile.log'
 # will redirect all STDOUT and STDERR to that logfile so this script will be
 # completely silent.
@@ -139,6 +143,10 @@ for GIT_REPO_URL in $GIT_REPO_URLS; do
         SRC_DIR_ABS_PATH="`pwd`/$SRC_DIR"
         USER_ID="`id -u`"
         GROUP_ID="`id -g`"
+        RSYNC_USER_GRP="$USER_ID:$GROUP_ID"
+        if [ ! -z "$DEPLOY_DATA_RSYNC_USER_GRP" ]; then
+            RSYNC_USER_GRP="$DEPLOY_DATA_RSYNC_USER_GRP"
+        fi
 
         # Ensure DEST_DIR_PARENT is created using current USER_ID/GROUP_ID for
         # next rsync to have proper write access.
@@ -148,7 +156,7 @@ for GIT_REPO_URL in $GIT_REPO_URLS; do
         docker run --rm --name deploy_data_rsync_$DOCKER_RUN_TAG \
             --volume $SRC_DIR_ABS_PATH:$SRC_DIR_ABS_PATH:ro \
             --volume $DEST_DIR_PARENT:$DEST_DIR_PARENT:rw \
-            --user $USER_ID:$GROUP_ID \
+            --user $RSYNC_USER_GRP \
             --entrypoint /usr/bin/rsync \
             $DEPLOY_DATA_RSYNC_IMAGE \
                 --recursive --links --checksum --delete \


### PR DESCRIPTION
When `deploy-data` is used by the `scheduler` component, it is run as
  `root`.  This new env var will force the rsync process to run as a regular user to
  follow security best practice to avoid running as root when not needed.

  Note that the `git checkout` step done by `deploy-data` is still run as root.
  This is because `deploy-data` is currently still run as root so it can
  execute `docker` commands (ex: spawning the `rsync` command above in its own
  docker container).

  To fix this limitation, the regular user inside the `deploy-data` container
  need to have docker access inside the container and outside on the host at
  the same time.  If we make that regular user configurable so the script
  `deploy-data` is generic and can work for any organisations, this is tricky
  for the moment so will have to be handle in another PR.

  So for the moment we have not achieved full non-root user in cronjobs
  launched by the `scheduler` compoment but the most important part, the part
  that perform the actual job (rsync or execute custom command using an
  external docker container) is running as non-root.

  See PR https://github.com/bird-house/birdhouse-deploy-ouranos/pull/18 that
  make use of this new env var.

  When `deploy-data` is invoking an external script that itself spawn a new
  `docker run`, then it is up to this external script to ensure the proper
  non-root user is used by `docker run`.
  See PR https://github.com/Ouranosinc/pavics-vdb/pull/50 that handle that
  case.