### PR TITLE
finch: new release for new Xclim

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.19.1
+current_version = 1.19.2
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,32 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- Finch: new release for new Xclim
+
+  Finch release notes:
+
+  0.9.2 (2022-07-19)
+  ------------------
+  * Fix Finch unable to startup in the Docker image.
+
+  0.9.1 (2022-07-07)
+  ------------------
+  * Avoid using a broken version of ``libarchive`` in the Docker image.
+
+  0.9.0 (2022-07-06)
+  ------------------
+  * Fix use of ``output_name``, add ``output_format`` to xclim indicators.
+  * Change all outputs to use ``output`` as the main output field name (instead of ``output_netcdf``).
+  * Updated to xclim 0.37:
+
+      - Percentile inputs of xclim indicators have been renamed with generic names, excluding an explicit mention to the target percentile.
+      - In ensemble processes, these percentiles can now be chosen through ``perc_[var]`` inputs. The default values are inherited from earlier versions of xclim.
+  * Average shape process downgraded to be single-threaded, as ESMF seems to have issues with multithreading.
+  * Removed deprecated processes ``subset_ensemble_bbox_BCCAQv2``, ``subset_ensemble_BCCAQv2`` and ``BCCAQv2_heat_wave_frequency_gridpoint``.
+  * Added ``csv_precision`` to all processes allowing CSV output. When given, it controls the number of decimal places in the output.
+
 
 [1.19.1](https://github.com/bird-house/birdhouse-deploy/tree/1.19.1) (2022-07-19)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.19.2](https://github.com/bird-house/birdhouse-deploy/tree/1.19.2) (2022-07-20)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes
 
 - Finch: new release for new Xclim

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.19.1.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.19.2.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.19.1...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.19.2...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.19.1-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.19.2-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.19.1
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.19.2
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -9,7 +9,7 @@ export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:220502"
 # to the order of the DOCKER_NOTEBOOK_IMAGES variable
 export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics"
 
-export FINCH_IMAGE="birdhouse/finch:version-0.8.3"
+export FINCH_IMAGE="birdhouse/finch:version-0.9.2"
 
 # thredds-docker >= 4.6.18 or >= 5.2 strongly recommended to avoid Log4J CVE-2021-44228.
 export THREDDS_IMAGE="unidata/thredds-docker:4.6.18"


### PR DESCRIPTION
PR to deploy this new Finch to PAVICS.  

Will need notebook fix for `climex.ipynb` and `subset-user-input.ipynb` in another PR.

Finch release notes:

  0.9.2 (2022-07-19)
  ==================
  * Fix Finch unable to startup in the Docker image.

  0.9.1 (2022-07-07)
  ==================
  * Avoid using a broken version of ``libarchive`` in the Docker image.

  0.9.0 (2022-07-06)
  ==================
  * Fix use of ``output_name``, add ``output_format`` to xclim indicators.
  * Change all outputs to use ``output`` as the main output field name (instead of ``output_netcdf``).
  * Updated to xclim 0.37:

      - Percentile inputs of xclim indicators have been renamed with generic names, excluding an explicit mention to the target percentile.
      - In ensemble processes, these percentiles can now be chosen through ``perc_[var]`` inputs. The default values are inherited from earlier versions of xclim.
  * Average shape process downgraded to be single-threaded, as ESMF seems to have issues with multithreading.
  * Removed deprecated processes ``subset_ensemble_bbox_BCCAQv2``, ``subset_ensemble_BCCAQv2`` and ``BCCAQv2_heat_wave_frequency_gridpoint``.
  * Added ``csv_precision`` to all processes allowing CSV output. When given, it controls the number of decimal places in the output.

FYI @ldperron 