### PR TITLE
Remove m2r2 in favour of sphinx-mdinclude

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 # extra requirements specifically for documentation purposes
-m2r2
-mistune==0.8.4
+sphinx-mdinclude

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'm2r2',  # add mdinclude
+    'sphinx_mdinclude',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Overview

Need to use `sphinx-mdinclude` since the newer version `mistune` do not work with `m2r2` on ReadTheDocs.  We needed the newer version of `mistune` for a security fix.

Error on ReadTheDocs  https://readthedocs.org/projects/birdhouse-deploy/builds/17578562/
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/birdhouse-deploy/envs/251/lib/python3.6/site-packages/sphinx/cmd/build.py", line 276, in build_main
    args.pdb)
  File "/home/docs/checkouts/readthedocs.org/user_builds/birdhouse-deploy/envs/251/lib/python3.6/site-packages/sphinx/application.py", line 222, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/birdhouse-deploy/envs/251/lib/python3.6/site-packages/sphinx/application.py", line 400, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/birdhouse-deploy/envs/251/lib/python3.6/site-packages/sphinx/registry.py", line 442, in load_extension
    mod = import_module(extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/birdhouse-deploy/envs/251/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/docs/checkouts/readthedocs.org/user_builds/birdhouse-deploy/envs/251/lib/python3.6/site-packages/m2r2.py", line 83, in <module>
    class RestBlockGrammar(mistune.BlockGrammar):
AttributeError: module 'mistune' has no attribute 'BlockGrammar'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/birdhouse-deploy/envs/251/lib/python3.6/site-packages/m2r2.py", line 83, in <module>
    class RestBlockGrammar(mistune.BlockGrammar):
AttributeError: module 'mistune' has no attribute 'BlockGrammar'
The full traceback has been saved in /tmp/sphinx-err-k8alw_js.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```


## Changes

**Non-breaking changes**
- Adds the `sphinx-mdinclude` library for converting markdown to RST. `sphinx-mdinclude` is very early-development fork of `m2r2` with much of the functionality stripped out (except for the mdinclude operation).

**Breaking changes**
- Removes `m2r2` and `mistune` from the docs dependencies

## Related Issue / Discussion

- Replaces PR https://github.com/bird-house/birdhouse-deploy/pull/251 that bumps `mistune` to `2.0.3` to get a security fix.
- Not created a tag for this merge since this is a documentation fix only and not affecting any deployments.

## Additional Information

Links to other issues or sources.

- [ ] Things to do...
