### PR TITLE
canarie-api: fix unable to verify LetsEncrypt SSL certs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.20.2
+current_version = 1.20.3
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,57 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes:
+- Canarie-api: fix unable to verify LetsEncrypt SSL certs
+
+  LetsEncrypt older root certificate "DST Root CA X3" expired on September 30,
+  2021, see https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
+
+  All the major browsers and OS platform has previously added the new root
+  certificate "ISRG Root X1" ahead of time so the transition to the new
+  root certificate is seemless for all clients.
+
+  Python `requests` package bundle their own copy of known root
+  certificates and is late to add this new root cert "ISRG Root X1".  Had
+  it automatically fallback to the OS copy of the root cert bundle, this
+  would have been seemless.
+
+  The fix is to force `requests` to use the OS copy of the root cert bundle.
+
+  Fix for this error:
+  ```
+  $ docker exec proxy python -c "import requests; requests.request('GET', 'https://lvupavicsmaster.ouranos.ca/geoserver')"
+  Traceback (most recent call last):
+    File "<string>", line 1, in <module>
+    File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 50, in request
+      response = session.request(method=method, url=url, **kwargs)
+    File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 468, in request
+      resp = self.send(prep, **send_kwargs)
+    File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 576, in send
+      r = adapter.send(request, **kwargs)
+    File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 433, in send
+      raise SSLError(e, request=request)
+  requests.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661)
+  ```
+
+  Default SSL root cert bundle of `requests`:
+  ```
+  $ docker exec proxy python -c "import requests; print requests.certs.where()"
+  /usr/local/lib/python2.7/dist-packages/requests/cacert.pem
+  ```
+
+  Confirm the fix works:
+  ```
+  $ docker exec -it proxy bash
+  root@37ed3a2a03ae:/opt/local/src/CanarieAPI/canarieapi# REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt python -c "import requests; requests.request('GET', 'https://lvupavicsmaster.ouranos.ca/geoserver')"
+  root@37ed3a2a03ae:/opt/local/src/CanarieAPI/canarieapi#
+
+  $ docker exec proxy env |grep REQ
+  REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+  ```
+
+  Fixes https://github.com/bird-house/birdhouse-deploy/issues/198
+
 
 [1.20.1](https://github.com/bird-house/birdhouse-deploy/tree/1.20.1) (2022-08-11)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.20.3](https://github.com/bird-house/birdhouse-deploy/tree/1.20.3) (2022-08-18)
+------------------------------------------------------------------------------------------------------------------
+
 ## Fixes:
 - Canarie-api: fix unable to verify LetsEncrypt SSL certs
 

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.20.2.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.20.3.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.20.2...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.20.3...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.20.2-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.20.3-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.20.2
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.20.3
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/config/canarie-api/docker_configuration.py.template
+++ b/birdhouse/config/canarie-api/docker_configuration.py.template
@@ -17,7 +17,7 @@ SERVICES = {
         'info': {
             'name': 'Node',
             'synopsis': 'Nodes are data, compute and index endpoints accessed through the PAVICS platform or external clients. The Node service is the backend that allows: data storage, harvesting, indexation and discovery of local and federated data; authentication and authorization; server registration and management. Node service is therefore composed of several other services.',
-            'version': '1.20.2',
+            'version': '1.20.3',
             'releaseTime': '2022-08-17T22:27:19Z',
             'institution': 'Ouranos',
             'researchSubject': 'Climatology',
@@ -242,7 +242,7 @@ PLATFORMS = {
         'info': {
             'name': 'PAVICS',
             'synopsis': 'The PAVICS (Power Analytics for Visualization of Climate Science) platform is a collection of climate analysis services served through Open Geospatial Consortium (OGC) protocols. These services include data access, processing and visualization. Both data and algorithms can be accessed either programmatically, through OGC-compliant clients such as QGIS or ArcGIS, or a custom web interface.',
-            'version': '1.20.2',
+            'version': '1.20.3',
             'releaseTime': '2022-08-17T22:27:19Z',
             'institution': 'Ouranos',
             'researchSubject': 'Climatology',

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     environment:
       CANARIE_API_CONFIG_FN: /config/docker_configuration.py
       CANARIE_MONITORING_EXTRA_CONF_DIR: ${CANARIE_MONITORING_EXTRA_CONF_DIR}
+      # https://github.com/bird-house/birdhouse-deploy/issues/198
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
     links:
       - thredds
     entrypoint: /entrypoint


### PR DESCRIPTION
LetsEncrypt older root certificate "DST Root CA X3" expired on September 30,
2021, see https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/

All the major browsers and OS platform has previously added the new root
certificate "ISRG Root X1" ahead of time so the transition to the new
root certificate is seemless for all clients.

Python `requests` package bundle their own copy of known root
certificates and is late to add this new root cert "ISRG Root X1".  Had
it automatically fallback to the OS copy of the root cert bundle, this
would have been seemless.

The fix is to force `requests` to use the OS copy of the root cert bundle.

Fix for this error:
```
$ docker exec proxy python -c "import requests; requests.request('GET', 'https://lvupavicsmaster.ouranos.ca/geoserver'
> )"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 50, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 468, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 433, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661)
```

Default SSL root cert bundle of `requests`:
```
$ docker exec proxy python -c "import requests; print requests.certs.where()"
/usr/local/lib/python2.7/dist-packages/requests/cacert.pem
```

Confirm the fix works:
```
$ docker exec -it proxy bash
root@37ed3a2a03ae:/opt/local/src/CanarieAPI/canarieapi# REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt python -c "import requests; requests.request('GET', 'https://lvupavicsmaster.ouranos.ca/geoserver')"
root@37ed3a2a03ae:/opt/local/src/CanarieAPI/canarieapi#

$ docker exec proxy env |grep REQ
REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
```

Fixes https://github.com/bird-house/birdhouse-deploy/issues/198