### PR TITLE
bump weaver to 4.22.0 by default - fixes for WPS remote provider execution

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,23 +1,23 @@
 [bumpversion]
-current_version = 1.20.3
+current_version = 1.20.4
 commit = True
 tag = False
 tag_name = {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+) (?P<releaseTime>.*)?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 	{now:%Y-%m-%dT%H:%M:%SZ}
 
 [bumpversion:file:CHANGES.md]
-search = 
+search =
 	[Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 	------------------------------------------------------------------------------------------------------------------
-replace = 
+replace =
 	[Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 	------------------------------------------------------------------------------------------------------------------
-	
+
 	[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
-	
+
 	[{new_version}](https://github.com/bird-house/birdhouse-deploy/tree/{new_version}) ({now:%Y-%m-%d})
 	------------------------------------------------------------------------------------------------------------------
 
@@ -26,7 +26,7 @@ search = {current_version}
 replace = {new_version}
 
 [bumpversion:part:releaseTime]
-values = 2021-03-26T00:00:00Z
+values = 2022-08-19T00:02:35Z
 
 [bumpversion:file(version):birdhouse/config/canarie-api/docker_configuration.py.template]
 search = 'version': '{current_version}'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,14 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+
+- Weaver: update `weaver` component default version to [4.21.0](https://github.com/crim-ca/weaver/tree/4.21.0).
+
+  ### Relevant changes
+  * Minor improvements to facilitate retrieval of XML and JSON Process definition and their seamless execution with 
+    XML or JSON request contents using either WPS or *OGC API - Processes* REST endpoints interchangeably.
+  * Fixes to WPS remote provider parsing registered in Weaver to successfully perform the relevant process executions.
 
 [1.20.1](https://github.com/bird-house/birdhouse-deploy/tree/1.20.1) (2022-08-11)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,12 +16,21 @@
 
 ## Changes:
 
-- Weaver: update `weaver` component default version to [4.21.0](https://github.com/crim-ca/weaver/tree/4.21.0).
+- Weaver: update `weaver` component default version to [4.22.0](https://github.com/crim-ca/weaver/tree/4.22.0).
 
   ### Relevant changes
   * Minor improvements to facilitate retrieval of XML and JSON Process definition and their seamless execution with 
     XML or JSON request contents using either WPS or *OGC API - Processes* REST endpoints interchangeably.
   * Fixes to WPS remote provider parsing registered in Weaver to successfully perform the relevant process executions.
+  * Add WPS remote provider retry conditions to handle known problematic cases during process execution (on remote)
+    that can lead to sporadic failures of the monitored job. When possible, retried submission leading to successful
+    execution will result in the monitored job to complete successfully and transparently to the user. Relevant errors
+    and retry attempts are provided in the job logs.
+  * Add WPS remote provider status exception response as XML message from the failed remote execution within the
+    monitored local job logs to help users understand how to resolve any encountered issue on the remote service.
+  * Bump version ``OWSLib==0.26.0`` to fix ``processVersion`` attribute resolution from WPS remote provider definition
+    to populate ``Process.version`` property employed in converted `Process` description to `OGC API - Process` schema
+    (relates to `geopython/OWSLib#794 <https://github.com/geopython/OWSLib/pull/794>`_).
 
 [1.20.1](https://github.com/bird-house/birdhouse-deploy/tree/1.20.1) (2022-08-11)
 ------------------------------------------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.20.4](https://github.com/bird-house/birdhouse-deploy/tree/1.20.4) (2022-08-19)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 
 - Weaver: update `weaver` component default version to [4.22.0](https://github.com/crim-ca/weaver/tree/4.22.0).

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.20.3.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.20.4.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.20.3...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.20.4...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.20.3-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.20.4-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.20.3
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.20.4
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/components/weaver/default.env
+++ b/birdhouse/components/weaver/default.env
@@ -35,7 +35,7 @@ VARS="$VARS $EXTRA_VARS"
 export WEAVER_CONFIG=HYBRID
 
 # default release version that will be used to fetch docker images (API mananger & celery workers services)
-export WEAVER_VERSION=4.20.0
+export WEAVER_VERSION=4.21.0
 
 # default release of the MongoDB version employed by Weaver
 # NOTE:

--- a/birdhouse/components/weaver/default.env
+++ b/birdhouse/components/weaver/default.env
@@ -35,7 +35,7 @@ VARS="$VARS $EXTRA_VARS"
 export WEAVER_CONFIG=HYBRID
 
 # default release version that will be used to fetch docker images (API mananger & celery workers services)
-export WEAVER_VERSION=4.21.0
+export WEAVER_VERSION=4.22.0
 
 # default release of the MongoDB version employed by Weaver
 # NOTE:

--- a/birdhouse/config/canarie-api/docker_configuration.py.template
+++ b/birdhouse/config/canarie-api/docker_configuration.py.template
@@ -17,8 +17,8 @@ SERVICES = {
         'info': {
             'name': 'Node',
             'synopsis': 'Nodes are data, compute and index endpoints accessed through the PAVICS platform or external clients. The Node service is the backend that allows: data storage, harvesting, indexation and discovery of local and federated data; authentication and authorization; server registration and management. Node service is therefore composed of several other services.',
-            'version': '1.20.3',
-            'releaseTime': '2022-08-17T22:27:19Z',
+            'version': '1.20.4',
+            'releaseTime': '2022-08-19T00:02:35Z',
             'institution': 'Ouranos',
             'researchSubject': 'Climatology',
             'supportEmail': '${SUPPORT_EMAIL}',
@@ -242,8 +242,8 @@ PLATFORMS = {
         'info': {
             'name': 'PAVICS',
             'synopsis': 'The PAVICS (Power Analytics for Visualization of Climate Science) platform is a collection of climate analysis services served through Open Geospatial Consortium (OGC) protocols. These services include data access, processing and visualization. Both data and algorithms can be accessed either programmatically, through OGC-compliant clients such as QGIS or ArcGIS, or a custom web interface.',
-            'version': '1.20.3',
-            'releaseTime': '2022-08-17T22:27:19Z',
+            'version': '1.20.4',
+            'releaseTime': '2022-08-19T00:02:35Z',
             'institution': 'Ouranos',
             'researchSubject': 'Climatology',
             'supportEmail': '${SUPPORT_EMAIL}',


### PR DESCRIPTION
## Overview

While working on https://github.com/crim-ca/weaver/pull/455, I found some errors parsing I/O during remote WPS processes execution. 

When the stack is evaluated with `weaver` component enabled, we can see that the test process `ncdump` on WPS `hummingbird` fails (process description works, but its execution fails at some point). For example, see failures in `pavics-sdi-master/docs/source/notebook-components/weaver_example.ipynb` output in https://github.com/bird-house/birdhouse-deploy/pull/253#issuecomment-1208753167.

<details>
<summary>Test Failure Details</summary>
<pre>
<code>
20:03:05  ---------------------------------------------------------------------------
20:03:05  AssertionError                            Traceback (most recent call last)
20:03:05  Input In [10], in <cell line: 8>()
20:03:05        6 path = f"{status_location}/results"
20:03:05        7 resp = requests.get(path, **WEAVER_TEST_REQUEST_XARGS)
20:03:05  ----> 8 assert resp.status_code == 200, f"Failed to retrieve job results location [{path}]. Code: [{resp.status_code}]."
20:03:05        9 body = resp.json()
20:03:05       11 # Here, our target output ID is named 'output' according to the process description
20:03:05  
20:03:05  AssertionError: Failed to retrieve job results location [https://host-140-44.rdext.crim.ca/weaver/providers/hummingbird/processes/ncdump/jobs/a66022f6-3897-4304-9b73-aa1e5de5423b/results]. Code: [400].
20:03:05  
20:03:05  =========================== short test summary info ============================
20:03:05  FAILED pavics-sdi-master/docs/source/notebooks/esgf-dap.ipynb::Cell 0
20:03:05  FAILED pavics-sdi-master/docs/source/notebook-components/weaver_example.ipynb::Cell 3
20:03:05  FAILED pavics-sdi-master/docs/source/notebook-components/weaver_example.ipynb::Cell 8
20:03:05  FAILED pavics-sdi-master/docs/source/notebook-components/weaver_example.ipynb::Cell 9
20:03:05  ============ 4 failed, 239 passed, 3 skipped in 1032.11s (0:17:12) =============
<br>
<br>
[2022-08-08T23:56:06.182Z] pavics-sdi-master/docs/source/notebook-components/weaver_example.ipynb . [ 57%]
[2022-08-08T23:56:16.309Z] ..F....FF.                                                               [ 61%]
</code>
</pre>
</details>


If the cause was the same as the one detected in the Weaver PR, tests should start passing. 

## Changes

**Non-breaking changes**
  * Minor improvements to facilitate retrieval of XML and JSON Process definition and their seamless execution with 
    XML or JSON request contents using either WPS or *OGC API - Processes* REST endpoints interchangeably.
  * Fixes to WPS remote provider parsing registered in Weaver to successfully perform the relevant process executions.

**Breaking changes**
- n/a

## Related Issue / Discussion

- https://github.com/crim-ca/weaver/pull/455


