### PR TITLE
fix bumpversion not updating server config version reference

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,19 +1,23 @@
 [bumpversion]
-current_version = 1.20.1
+current_version = 1.20.2
 commit = True
 tag = False
 tag_name = {new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+) (?P<releaseTime>.*)?
+serialize = 
+	{major}.{minor}.{patch}
+	{now:%Y-%m-%dT%H:%M:%SZ}
 
 [bumpversion:file:CHANGES.md]
-search =
+search = 
 	[Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 	------------------------------------------------------------------------------------------------------------------
-replace =
+replace = 
 	[Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 	------------------------------------------------------------------------------------------------------------------
-
+	
 	[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
-
+	
 	[{new_version}](https://github.com/bird-house/birdhouse-deploy/tree/{new_version}) ({now:%Y-%m-%d})
 	------------------------------------------------------------------------------------------------------------------
 
@@ -21,6 +25,14 @@ replace =
 search = {current_version}
 replace = {new_version}
 
-[bumpversion:file:birdhouse/config/canarie-api/docker_configuration.py.template]
+[bumpversion:part:releaseTime]
+values = 2021-03-26T00:00:00Z
+
+[bumpversion:file(version):birdhouse/config/canarie-api/docker_configuration.py.template]
 search = 'version': '{current_version}'
 replace = 'version': '{new_version}'
+
+[bumpversion:file(releaseTime):birdhouse/config/canarie-api/docker_configuration.py.template]
+parse = 'releaseTime': '(?P<releaseTime>.*)'
+serialize = {releaseTime}
+replace = {now:%Y-%m-%dT%H:%M:%SZ}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,18 +5,22 @@ tag = False
 tag_name = {new_version}
 
 [bumpversion:file:CHANGES.md]
-search = 
+search =
 	[Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 	------------------------------------------------------------------------------------------------------------------
-replace = 
+replace =
 	[Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 	------------------------------------------------------------------------------------------------------------------
-	
+
 	[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
-	
+
 	[{new_version}](https://github.com/bird-house/birdhouse-deploy/tree/{new_version}) ({now:%Y-%m-%d})
 	------------------------------------------------------------------------------------------------------------------
 
 [bumpversion:file:README.rst]
 search = {current_version}
 replace = {new_version}
+
+[bumpversion:file:birdhouse/config/canarie-api/docker_configuration.py.template]
+search = 'version': '{current_version}'
+replace = 'version': '{new_version}'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
+[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+
+[1.20.2](https://github.com/bird-house/birdhouse-deploy/tree/1.20.2) (2022-08-17)
+------------------------------------------------------------------------------------------------------------------
+
 ## Changes:
 - birdhouse-deploy: fix missing bump of server version reported in ``canarie`` service configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,8 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes:
+- birdhouse-deploy: fix missing bump of server version reported in ``canarie`` service configuration
 
 [1.20.1](https://github.com/bird-house/birdhouse-deploy/tree/1.20.1) (2022-08-11)
 ------------------------------------------------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ for a full-fledged production platform.
     * - releases
       - | |latest-version| |commits-since|
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.20.1.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/bird-house/birdhouse-deploy/1.20.2.svg
     :alt: Commits since latest release
-    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.20.1...master
+    :target: https://github.com/bird-house/birdhouse-deploy/compare/1.20.2...master
 
-.. |latest-version| image:: https://img.shields.io/badge/tag-1.20.1-blue.svg?style=flat
+.. |latest-version| image:: https://img.shields.io/badge/tag-1.20.2-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.20.1
+    :target: https://github.com/bird-house/birdhouse-deploy/tree/1.20.2
 
 .. |readthedocs| image:: https://readthedocs.org/projects/birdhouse-deploy/badge/?version=latest
     :alt: ReadTheDocs Build Status (latest version)

--- a/birdhouse/config/canarie-api/docker_configuration.py.template
+++ b/birdhouse/config/canarie-api/docker_configuration.py.template
@@ -17,9 +17,9 @@ SERVICES = {
         'info': {
             'name': 'Node',
             'synopsis': 'Nodes are data, compute and index endpoints accessed through the PAVICS platform or external clients. The Node service is the backend that allows: data storage, harvesting, indexation and discovery of local and federated data; authentication and authorization; server registration and management. Node service is therefore composed of several other services.',
-            'version': '1.20.1',
+            'version': '1.20.2',
+            'releaseTime': '2022-08-17T22:27:19Z',
             'institution': 'Ouranos',
-            'releaseTime': '2021-03-26T00:00:00Z',
             'researchSubject': 'Climatology',
             'supportEmail': '${SUPPORT_EMAIL}',
             'category': 'Resource/Cloud Management',
@@ -242,9 +242,9 @@ PLATFORMS = {
         'info': {
             'name': 'PAVICS',
             'synopsis': 'The PAVICS (Power Analytics for Visualization of Climate Science) platform is a collection of climate analysis services served through Open Geospatial Consortium (OGC) protocols. These services include data access, processing and visualization. Both data and algorithms can be accessed either programmatically, through OGC-compliant clients such as QGIS or ArcGIS, or a custom web interface.',
-            'version': '1.20.1',
+            'version': '1.20.2',
+            'releaseTime': '2022-08-17T22:27:19Z',
             'institution': 'Ouranos',
-            'releaseTime': '2021-03-26T00:00:00Z',
             'researchSubject': 'Climatology',
             'supportEmail': '${SUPPORT_EMAIL}',
             'tags': ['Climatology', 'Cloud']

--- a/birdhouse/config/canarie-api/docker_configuration.py.template
+++ b/birdhouse/config/canarie-api/docker_configuration.py.template
@@ -17,7 +17,7 @@ SERVICES = {
         'info': {
             'name': 'Node',
             'synopsis': 'Nodes are data, compute and index endpoints accessed through the PAVICS platform or external clients. The Node service is the backend that allows: data storage, harvesting, indexation and discovery of local and federated data; authentication and authorization; server registration and management. Node service is therefore composed of several other services.',
-            'version': '1.11.25',
+            'version': '1.20.1',
             'institution': 'Ouranos',
             'releaseTime': '2021-03-26T00:00:00Z',
             'researchSubject': 'Climatology',
@@ -242,7 +242,7 @@ PLATFORMS = {
         'info': {
             'name': 'PAVICS',
             'synopsis': 'The PAVICS (Power Analytics for Visualization of Climate Science) platform is a collection of climate analysis services served through Open Geospatial Consortium (OGC) protocols. These services include data access, processing and visualization. Both data and algorithms can be accessed either programmatically, through OGC-compliant clients such as QGIS or ArcGIS, or a custom web interface.',
-            'version': '1.11.25',
+            'version': '1.20.1',
             'institution': 'Ouranos',
             'releaseTime': '2021-03-26T00:00:00Z',
             'researchSubject': 'Climatology',


### PR DESCRIPTION
## Overview

Platform version reported by ``canarie`` service was not kept up to date with tagged versions.

## Changes

**Non-breaking changes**
- Add bumpversion config entry to update references on future bump.

**Breaking changes**
- n/a

