### PR TITLE
support display image names with version on jupyterhub

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,10 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes:
+
+- Fix the Docker Spawner `start` function to support JupyterHub image selection names 
+  that use the `<name>:<version>` format.
 
 [1.22.7](https://github.com/bird-house/birdhouse-deploy/tree/1.22.7) (2022-12-23)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -28,12 +28,22 @@ class CustomDockerSpawner(DockerSpawner):
             host_dir = join(os.environ['JUPYTERHUB_USER_DATA_DIR'], 'tutorial-notebooks-specific-images')
 
             # Mount a volume with a tutorial-notebook subfolder corresponding to the image name, if it exists
+            # The names are defined in the JUPYTERHUB_IMAGE_SELECTION_NAMES variable.
             image_name = self.user_options.get('image')
             if(os.path.isdir(join(host_dir, image_name))):
                 self.volumes[join(host_dir, image_name)] = {
                     "bind": '/notebook_dir/tutorial-notebooks',
                     "mode": "ro"
                 }
+            else:
+                # Try again, removing any colons and any following text. Useful if the image name contains
+                # the version number, which should not be used in the directory name.
+                image_name = image_name.split(':')[0]
+                if(os.path.isdir(join(host_dir, image_name))):
+                    self.volumes[join(host_dir, image_name)] = {
+                        "bind": '/notebook_dir/tutorial-notebooks',
+                        "mode": "ro"
+                    }
         else:
             # Mount the entire tutorial-notebooks directory
             self.volumes[join(os.environ['JUPYTERHUB_USER_DATA_DIR'], "tutorial-notebooks")] = {

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -10,8 +10,9 @@ export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:221130"
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond
 # to the order of the DOCKER_NOTEBOOK_IMAGES variable
-# Note that the names here (or the names preceding each ':', if the version is included) are also used as directory
-# names for the tutorial-notebooks directories mounted when starting the corresponding image.
+# Note that the selection names are also used as directory names for the tutorial-notebooks directories mounted when
+# starting the corresponding image. The name can use the '<name>' or the '<name>:<version>' format. The version will be
+# excluded when mounting the corresponding directory.
 export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.9.2"

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -10,6 +10,8 @@ export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:221130"
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond
 # to the order of the DOCKER_NOTEBOOK_IMAGES variable
+# Note that the names here (or the names preceding each ':', if the version is included) are also used as directory
+# names for the tutorial-notebooks directories mounted when starting the corresponding image.
 export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics"
 
 export FINCH_IMAGE="birdhouse/finch:version-0.9.2"

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -237,6 +237,8 @@ export GEOSERVER_ADMIN_PASSWORD=geoserverpass
 # Name of the images displayed on the JupyterHub image selection page
 # The name order must correspond to the order of the DOCKER_NOTEBOOK_IMAGES variable,
 # and both variables should have the same number of entries.
+# Note that the names here (or the names preceding each ':', if the version is included) are also used as directory
+# names for the tutorial-notebooks directories mounted when starting the corresponding image.
 #export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics \
 #                                         eo-crim \
 #                                         nlp-crim"

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -237,8 +237,9 @@ export GEOSERVER_ADMIN_PASSWORD=geoserverpass
 # Name of the images displayed on the JupyterHub image selection page
 # The name order must correspond to the order of the DOCKER_NOTEBOOK_IMAGES variable,
 # and both variables should have the same number of entries.
-# Note that the names here (or the names preceding each ':', if the version is included) are also used as directory
-# names for the tutorial-notebooks directories mounted when starting the corresponding image.
+# Note that the selection names are also used as directory names for the tutorial-notebooks directories mounted when
+# starting the corresponding image. The name can use the '<name>' or the '<name>:<version>' format. The version will be
+# excluded when mounting the corresponding directory.
 #export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics \
 #                                         eo-crim \
 #                                         nlp-crim"

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -241,7 +241,7 @@ export GEOSERVER_ADMIN_PASSWORD=geoserverpass
 # starting the corresponding image. The name can use the '<name>' or the '<name>:<version>' format. The version will be
 # excluded when mounting the corresponding directory.
 #export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics \
-#                                         eo-crim \
+#                                         eo-crim:0.3.0 \
 #                                         nlp-crim"
 
 # allow jupyterhub user selection of which notebook image to run


### PR DESCRIPTION
Fix to support JupyterHub image selection names that use the `<name>:<version>` format. 

Initially, we were only displaying the name of the images on the JupyterHub page, but we added the version to give more information to the user. This requires the adjustment found in this PR, since we rely on those values to find a corresponding directory to mount when starting the image. The directory should only be named using the `name` part, and should exclude the `version`. 

For example, if we display an option `eo-crim:0.3.0` on the JupyterHub selection page, the image used to start JupyterLab should mount the directory `eo-crim`, which should contain its corresponding tutorial notebooks.

I also added some more comments to clarify the relationship between the names displayed on the JupyterHub page and directory names used for the notebooks of each corresponding image.

This should be backward compatible, still working if we only use the name instead of the `<name>:<version>` format.

Related to [pavics-jupyter-base PR](https://github.com/bird-house/pavics-jupyter-base/pull/7)