### PR TITLE
replace check-instance-ready endpoint to use status instead of stats from CanarieAPI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,13 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes:
+- Scripts: fix [`check-instance-ready`](birdhouse/scripts/check-instance-ready) script.
+  
+  Previously employed `/canarie/node/service/stats` endpoint could be unreliable for some services under the node that
+  produced log collection errors to populate stats. Instead, use `/canarie/node/service/status` that check only if the
+  services are responsive according to configured endpoints under CanarieAPI. This status endpoint is the same one that
+  is employed by the CI test suite to check that the instance is ready before starting notebook tests.
 
 [1.23.0](https://github.com/bird-house/birdhouse-deploy/tree/1.23.0) (2023-02-10)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/scripts/check-instance-ready
+++ b/birdhouse/scripts/check-instance-ready
@@ -13,11 +13,13 @@ COMPOSE_DIR="`dirname "$THIS_DIR"`"
 
 if [ -f "$COMPOSE_DIR/env.local" ]; then
     # Get PAVICS_FQDN
-    . $COMPOSE_DIR/env.local
+    . "${COMPOSE_DIR}/env.local"
 fi
 
+MONITOR_URL="https://${PAVICS_FQDN}/canarie/node/service/status"
+
 set -x
-curl --include --silent https://$PAVICS_FQDN/canarie/node/service/stats | head
+curl --include --silent "${MONITOR_URL}" | head
 
 set +x
 echo "
@@ -25,11 +27,11 @@ The curl above should return the HTTP response code 200 to confirm instance is r
 "
 set -x
 
-HTTP_RESPONSE_CODE="`curl --write-out '%{http_code}' --output /dev/null --silent https://$PAVICS_FQDN/canarie/node/service/stats`"
-if [ $HTTP_RESPONSE_CODE -ne 200 ]; then
+HTTP_RESPONSE_CODE=$(curl --write-out '%{http_code}' --output /dev/null --silent "${MONITOR_URL}")
+if [ "${HTTP_RESPONSE_CODE}" -ne 200 ]; then
     set +x
     echo "
-HTTP response code received: $HTTP_RESPONSE_CODE (expected 200).
+HTTP response code received: ${HTTP_RESPONSE_CODE} (expected 200).
 
 Will sleep for about 1 minute and try again since the canarie-api refresh every minute.
 
@@ -37,5 +39,5 @@ Will retry only once more and exit immediately.
 "
 set -x
     sleep 65
-    curl --include --silent https://$PAVICS_FQDN/canarie/node/service/stats | head
+    curl --include --silent "${MONITOR_URL}" | head
 fi


### PR DESCRIPTION

## Overview

Fix errors seen in https://github.com/bird-house/birdhouse-deploy/pull/283#issuecomment-1426066739 and https://github.com/bird-house/birdhouse-deploy/pull/283#issuecomment-1426093464. 

More precisely, the `/stats` endpoint indicates 503, while all services under it seems OK
(https://host-140-154.rdext.crim.ca/canarie/node/service/stats)
![image](https://user-images.githubusercontent.com/19194484/218157005-14ee21fb-b03b-4ca2-9498-5862cca7d3b6.png)

Using `/status` is more reliable
(https://host-140-154.rdext.crim.ca/canarie/node/service/status)
![image](https://user-images.githubusercontent.com/19194484/218157148-d7f3eb48-f791-4eb1-a6b0-11cff514c1ad.png)


## Changes

**Non-breaking changes**

- Scripts: fix [`check-instance-ready`](birdhouse/scripts/check-instance-ready) script.

  Previously employed `/canarie/node/service/stats` endpoint could be unreliable for some services under the node that
  produced log collection errors to populate stats. Instead, use `/canarie/node/service/status` that check only if the
  services are responsive according to configured endpoints under CanarieAPI. This status endpoint is the same one that
  is employed by the CI test suite to check that the instance is ready before starting notebook tests.

**Breaking changes**
- n/a

## Related Issue / Discussion

- Resolves problems seen in latest PR build/test of https://github.com/bird-house/birdhouse-deploy/pull/283

