### PR TITLE
`components/` endpoint displays intended information after auto-deploy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,16 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+- `components/` endpoint displays intended information after auto-deploy
+
+  Previously, the script that generates the content for the `components/` endpoint
+  was using a feature of `grep` that is not supported by all versions of `grep`.
+  This meant that this script running in the auto-deployment docker container was
+  not able to properly parse the running components using `grep`. 
+  This fixes the issue by making the script compliant with all versions of `grep`.
+
+  Resolves https://github.com/bird-house/birdhouse-deploy/issues/342
 
 [1.26.4](https://github.com/bird-house/birdhouse-deploy/tree/1.26.4) (2023-06-06)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/scripts/get-components-json.include.sh
+++ b/birdhouse/scripts/get-components-json.include.sh
@@ -37,6 +37,8 @@ cd "${BIRDHOUSE_DEPLOY_COMPONENTS_ROOT}" || true  # ignore error for now, empty 
 BIRDHOUSE_DEPLOY_COMPONENTS_LIST_KNOWN="$( \
   ls -d1 ./*components/*/ ./config/*/ 2>/dev/null \
   | sed -E "s|\./(.*)/|\1|" \
+  | sed -E '/^[[:space:]]*$/d' \
+  | sed -E 's/^|[[:space:]]+/ -e /' \
 )"
 if [ -z "${BIRDHOUSE_DEPLOY_COMPONENTS_LIST_KNOWN}" ]; then
   echo "[WARNING]" \
@@ -56,7 +58,7 @@ BIRDHOUSE_DEPLOY_COMPONENTS_LIST_ACTIVE=$( \
 BIRDHOUSE_DEPLOY_COMPONENTS_BASE="bird-house/birdhouse-deploy:"
 BIRDHOUSE_DEPLOY_COMPONENTS_LIST=$( \
   echo "${BIRDHOUSE_DEPLOY_COMPONENTS_LIST_ACTIVE}" \
-  | grep "${BIRDHOUSE_DEPLOY_COMPONENTS_LIST_KNOWN}" \
+  | grep ${BIRDHOUSE_DEPLOY_COMPONENTS_LIST_KNOWN} \
   | sed -E 's|^\s*([A-Za-z0-0./_-]+)\s*$|"\1",|g' \
   | sed -E "s|^\"\./(.*)\"|\"${BIRDHOUSE_DEPLOY_COMPONENTS_BASE}\\1\"|g" \
   | sed '/^\n*$/d' \


### PR DESCRIPTION
## Overview

Previously, the script that generates the content for the `components/` endpoint was using a feature of `grep` that is not supported by all versions of `grep`.
  
This meant that this script running in the auto-deployment docker container was not able to properly parse the running components using `grep`. 

This fixes the issue by making the script compliant with all versions of `grep`.

## Changes

**Non-breaking changes**

None: bugfix

**Breaking changes**

None

## Related Issue / Discussion

- Resolves #342 

## Additional Information
