### PR TITLE
Docker compose version missing in ``stac/config/magpie/`` compose file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,11 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Docker compose version missing in ``stac/config/magpie/`` compose file
+  - The ``version:`` key was not set in the ``stac/config/magpie/docker-compose-extra.yml`` file which caused
+    ``docker-compose`` to report a version mismatch and fail to start.
 
 [1.31.3](https://github.com/bird-house/birdhouse-deploy/tree/1.31.3) (2023-09-21)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/stac/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/stac/config/magpie/docker-compose-extra.yml
@@ -1,3 +1,5 @@
+version: "3.4"
+
 services:
   magpie:
     volumes:


### PR DESCRIPTION
## Overview

The `version:` key was not set in the `stac/config/magpie/docker-compose-extra.yml` file which caused `docker-compose` to report a version mismatch and fail to start.

## Changes

**Non-breaking changes**
- Bug fix

**Breaking changes**
None

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci: true`` in the PR description. 
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
