### PR TITLE
jupyter: new incremental build to include `SAlib` for sensitivity analysis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,16 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+- Jupyter: new incremental build to include `SAlib` for sensitivity analysis
+
+  Also make `/notebook_dir/` read-only to avoid users putting their files there
+  and losing them since only `/notebook_dir/writable-workspace` is persisted on
+  disk.
+
+  See https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/128 for more
+  details.
+
 
 [1.37.1](https://github.com/bird-house/birdhouse-deploy/tree/1.37.1) (2023-11-03)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/config/jupyterhub/default.env
+++ b/birdhouse/config/jupyterhub/default.env
@@ -8,7 +8,7 @@ export JUPYTERHUB_DOCKER=pavics/jupyterhub
 export JUPYTERHUB_VERSION=4.0.2-20231002
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:230601"
+export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:py39-230601-1-update231025"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond


### PR DESCRIPTION
Also make `/notebook_dir/` read-only to avoid users putting their files there and losing them since only `/notebook_dir/writable-workspace` is persisted on disk.

See https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/128 for more details.

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
