### PR TITLE
Allow users to log in to Jupyterhub with their email address

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,16 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Allow users to log in to Jupyterhub with their email address
+
+  Previously, JupyterHub's `MagpieAuthenticator` class treated the email address entered into the username field as
+  the username itself. This led to a mismatch between the username in JupyterHub and the username in Magpie.
+  To resolve this, we update the JupyterHub docker image to a version where this bug is fixed. 
+
+  See https://github.com/Ouranosinc/jupyterhub/pull/26 and https://github.com/Ouranosinc/Magpie/issues/598 for 
+  reference.
 
 [2.0.3](https://github.com/bird-house/birdhouse-deploy/tree/2.0.3) (2024-01-16)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/jupyterhub/default.env
+++ b/birdhouse/components/jupyterhub/default.env
@@ -5,7 +5,7 @@
 # are applied and must be added to the list of DELAYED_EVAL.
 
 export JUPYTERHUB_DOCKER=pavics/jupyterhub
-export JUPYTERHUB_VERSION=4.0.2-20231127
+export JUPYTERHUB_VERSION=4.0.2-20240117
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
 export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:py39-230601-1-update231122"


### PR DESCRIPTION
## Overview

Previously, JupyterHub's `MagpieAuthenticator` class treated the email address entered into the username field as the username itself. This led to a mismatch between the username in JupyterHub and the username in Magpie.

To resolve this, we update the JupyterHub docker image to a version where this bug is fixed. 

See https://github.com/Ouranosinc/jupyterhub/pull/26 and https://github.com/Ouranosinc/Magpie/issues/598 for reference.

## Changes

**Non-breaking changes**
- Update jupyterhub to version 4.0.2-20240117

**Breaking changes**

## Related Issue / Discussion

- Resolves https://github.com/Ouranosinc/Magpie/issues/598 

## Additional Information

Links to other issues or sources.

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci: true`` in the PR description. 
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
