### PR TITLE
env.local.example: fix `JUPYTERHUB_CONFIG_OVERRIDE` comment section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,12 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- env.local.example: fix `JUPYTERHUB_CONFIG_OVERRIDE` comment section
+
+  `JUPYTERHUB_CONFIG_OVERRIDE` was disconnected from its sample code.
+
 
 [2.0.6](https://github.com/bird-house/birdhouse-deploy/tree/2.0.6) (2024-02-15)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -356,12 +356,6 @@ export GEOSERVER_ADMIN_PASSWORD=geoserverpass
 # it will be automatically reduced by half of the timeout value to ensure that it can be effective.
 #export JUPYTER_IDLE_KERNEL_CULL_INTERVAL=0
 
-# Allow for adding new config or override existing config in
-# config/jupyterhub/jupyterhub_config.py.template.
-#
-#export JUPYTERHUB_CONFIG_OVERRIDE="
-#
-#
 # The following variables can be used to configure additional authentication settings for jupyterhub
 #
 # 32 byte hex-encoded key used to encrypt a user's authentication state in the juptyerhub database.
@@ -376,7 +370,11 @@ export GEOSERVER_ADMIN_PASSWORD=geoserverpass
 # if their authentication information is older that this value (in seconds). This value is only applied if
 # JUPYTERHUB_CRYPT_KEY is set.
 #export JUPYTERHUB_AUTHENTICATOR_REFRESH_AGE=60
+
+# Allow for adding new config or override existing config in
+# config/jupyterhub/jupyterhub_config.py.template.
 #
+#export JUPYTERHUB_CONFIG_OVERRIDE="
 #
 # Sample below will allow for sharing notebooks between Jupyter users.
 # Note all shares are public.


### PR DESCRIPTION
`JUPYTERHUB_CONFIG_OVERRIDE` was disconnected from its sample code.

This is just a comment fix.  Zero chance to introduce any regressions.

I won't tag it upon merging this PR.