### PR TITLE
Adding the marble image to notebook images list

### DIFF
--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -263,7 +263,8 @@ export GEOSERVER_ADMIN_PASSWORD="${__DEFAULT__GEOSERVER_ADMIN_PASSWORD}"
 #export ALLOW_UNSECURE_HTTP=""
 
 # Jupyter single-user server images
-#export DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:210216 \
+#export DOCKER_NOTEBOOK_IMAGES="marbleclimate/marble-jupyter-images \
+#                               pavics/workflow-tests:210216 \
 #                               pavics/crim-jupyter-eo:0.3.0 \
 #                               pavics/crim-jupyter-nlp:0.4.0 \
 #                               birdhouse/pavics-jupyter-base:mlflow-proxy"
@@ -274,7 +275,8 @@ export GEOSERVER_ADMIN_PASSWORD="${__DEFAULT__GEOSERVER_ADMIN_PASSWORD}"
 # Note that the selection names are also used as directory names for the tutorial-notebooks directories mounted when
 # starting the corresponding image. The name can use the '<name>' or the '<name>:<version>' format. The version will be
 # excluded when mounting the corresponding directory.
-#export JUPYTERHUB_IMAGE_SELECTION_NAMES="pavics \
+#export JUPYTERHUB_IMAGE_SELECTION_NAMES="marble \
+#                                         pavics \
 #                                         eo-crim:0.3.0 \
 #                                         nlp-crim \
 #                                         mlflow-crim"


### PR DESCRIPTION
## Overview

Adding the newly created [marble Jupyter image](https://hub.docker.com/repository/docker/marbleclimate/marble-jupyter-images/general) to the notebook image selections list.  

## Changes

**Non-breaking changes**
- Changes are made to `env.local.example`


<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci: true`` in the PR description. 
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
