### PR TITLE
update GitHub issue+pr templates assignees

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @tlvu @fmigneault @mishaschwartz

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,7 +3,7 @@ name: ":bug: Bug Report"
 about: Create an issue related to a bug or encountered problem.
 title: ":bug: [BUG]: "
 labels: bug
-assignees: tlvu, MatProv
+assignees: tlvu, fmigneault, mishaschwartz
 
 ---
 
@@ -45,4 +45,3 @@ Steps to reproduce the behavior:
 
   @tag them below 
 -->
-

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -3,7 +3,7 @@ name: ":books: Documentation"
 about: Report an issue related to missing, incorrect or insufficient documentation.
 title: ":books: [Documentation]: "
 labels: documentation
-assignees: tlvu
+assignees: tlvu, fmigneault, mishaschwartz
 ---
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: Feature Request
 about: Suggest an idea, new feature or enhancement to existing functionalities.
 title: ":bulb: [Feature]"
 labels: enhancement 
-assignees: tlvu
+assignees: tlvu, fmigneault, mishaschwartz
 
 ---
 
@@ -33,4 +33,3 @@ assignees: tlvu
 
   @tag them below
 -->
-

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -3,7 +3,7 @@ name: ":question: Question"
 about: Ask a question or request general help support.
 title: ":question: [Question]: "
 labels: question
-assignees: tlvu, MatProv
+assignees: tlvu, fmigneault, mishaschwartz
 ---
 
 ## Questions


### PR DESCRIPTION
## Overview

No change to the platform. Only GitHub issue templates assignees are modified.

## Changes

**Non-breaking changes**
- Change GitHub issue templates assignees for latest organization maintainers.
- Add CODEOWNERS file for default PR reviewers with same organization maintainers.

**Breaking changes**
- n/a
- 
## Related Issue / Discussion

- n/a

## Additional Information

- n/a

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
