### PR TITLE
remove explicit `birdhouse_skip_ci: true` from PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -45,4 +45,3 @@ Steps to reproduce the behavior:
 
   @tag them below 
 -->
-

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -33,4 +33,3 @@ assignees: tlvu
 
   @tag them below
 -->
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,9 +26,12 @@ Links to other issues or sources.
 
 - [ ] Things to do...
 
+## CI Operations
+
 <!--
   The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
-  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci: true`` in the PR description. 
+  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.
+  Note that using ``[skip ci]``, ``[ci skip]`` or ``[no ci]`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
 -->
 
 birdhouse_daccs_configs_branch: master


### PR DESCRIPTION
## Overview

Remove explicit `birdhouse_skip_ci: true` from PR template
(note: this one above is left in there on purpose for the current PR)

When opening PRs, developers could easily leave in the `<!-- -->` comment about CI, causing the CI to falsely detect the condition when parsing the PR description, and ending up skipping it. Change the format of the sentence to avoid the false detection.

## Changes

**Non-breaking changes**
- Edit PR template.

**Breaking changes**
- n/a

## Related Issue / Discussion

- n/a

## CI Operations

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
