### PR TITLE
fix content-type of geoserver service-config.json.template

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,8 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+- GeoServer: fix invalid media-type specified for the service's endpoint in `service-config.json.template`
 
 [2.1.2](https://github.com/bird-house/birdhouse-deploy/tree/2.1.2) (2024-03-25)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/geoserver/service-config.json.template
+++ b/birdhouse/components/geoserver/service-config.json.template
@@ -11,7 +11,7 @@
   "links": [
     {
       "rel": "service",
-      "type": "application/json",
+      "type": "text/html",
       "href": "https://${PAVICS_FQDN_PUBLIC}/geoserver/"
     },
     {


### PR DESCRIPTION
## Overview

The `/geoserver` endpoint redirects to the HTML web view of the service.
Fix the indicated media-type of `type` for that endpoint in the service definition.

## Changes

**Non-breaking changes**
- fix content-type of GeoServer `service-config.json.template`

**Breaking changes**
- n/a

## Related Issue / Discussion

- n/a

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.
  Note that using ``[skip ci]``, ``[ci skip]`` or ``[no ci]`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
