### PR TITLE
fix readthedocs build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,13 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- docs: Fix version of `sphinx-mdinclude` to address incompatible `docutils` operation under ReadTheDocs Sphinx build.
+
+  - See [docutils 0.21 changes](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2024-04-09).
+  - See issue [sphinx-mdinclude#47](https://github.com/omnilib/sphinx-mdinclude/issues/47)
+    and PR [sphinx-mdinclude#55](https://github.com/omnilib/sphinx-mdinclude/pull/55).
 
 [2.2.0](https://github.com/bird-house/birdhouse-deploy/tree/2.2.0) (2024-04-18)
 ------------------------------------------------------------------------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 # extra requirements specifically for documentation purposes
-sphinx-mdinclude
+sphinx-mdinclude>=0.5.4


### PR DESCRIPTION

## Overview

Issue seen on https://readthedocs.org/projects/birdhouse-deploy/builds/24109903/
`AttributeError: module 'docutils.nodes' has no attribute 'reprunicode'`

## Changes

**Non-breaking changes**
- docs: Fix version of `sphinx-mdinclude` to address incompatible `docutils` operation under ReadTheDocs Sphinx build.

**Breaking changes**
- n/a

## Related Issue / Discussion


  - See [docutils 0.21 changes](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2024-04-09).
  - See issue [sphinx-mdinclude#47](https://github.com/omnilib/sphinx-mdinclude/issues/47)     and PR [sphinx-mdinclude#55](https://github.com/omnilib/sphinx-mdinclude/pull/55).
