### PR TITLE
weaver: bump version to 5.1.0 + debug notebook output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,14 @@
   - See changes in the [Weaver changes 
     file](https://github.com/crim-ca/weaver/blob/ec5f403958de21e1af27ff86da391d0d53ded5d9/CHANGES.rst?plain=1#L23-L249)
 
+## Fixes
+
+- Weaver: WPS retry logic on post-compose step.
+  - Apply `--network birdhouse_default` to the Docker `curl` image to allow HTTP requests to properly resolve
+    against the running services (WPS bird providers, Weave and Magpie). In some cases, this network would not
+    be automatically resolved.
+  - Fix the index used during HTTP request retry to avoid going one step over the intended retry attempts.
+
 [2.2.0](https://github.com/bird-house/birdhouse-deploy/tree/2.2.0) (2024-04-18)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/birdhouse/components/weaver/post-docker-compose-up
+++ b/birdhouse/components/weaver/post-docker-compose-up
@@ -120,7 +120,7 @@ RANDOM_NUMBER=${RANDOM:-$(tr -dc 0-9 < /dev/urandom 2>/dev/null | head -c 5)}
 # To know when a docker run was started in case it hangs.
 DOCKER_RUN_TAG="weaver_post_curl_$(date -Isecond | sed 's/:/_/g' | sed 's/+/p/g')_${RANDOM_NUMBER}"
 curl_cmd() {
-    docker run --rm --name "${DOCKER_RUN_TAG}" "${WEAVER_CURL_IMAGE}" "$@"
+    docker run --network birdhouse_default --rm --name "${DOCKER_RUN_TAG}" "${WEAVER_CURL_IMAGE}" "$@"
 }
 
 # pull image if missing to avoid mangling output messages on first call
@@ -317,7 +317,7 @@ for prov in ${WEAVER_WPS_PROVIDERS}; do
         if [ ${ret} -ne 0 ] || [ "${code}" -ne 201 ]; then
             printf "\n%s\n" "${WARN}Failed registration of remote WPS provider [${prov}] on [${prov_url}]${retry_msg}."
             printf "Error:\n%s\n" "${body}"
-            if [ ${retry} -gt ${total} ]; then
+            if [ ${retry} -ge ${total} ]; then
               echo "${ERROR}Maximum retry attempts ${total} reached for WPS provider [${prov}]. Aborting."
               reset_state
               exit 23


### PR DESCRIPTION
## Overview

Debugging cause of diff in final output of https://github.com/Ouranosinc/pavics-sdi/blob/master/docs/source/notebook-components/weaver_example.ipynb

Built on top of https://github.com/bird-house/birdhouse-deploy/pull/439

## Changes

**Non-breaking changes**
- New component version Weaver: 5.1.1
- Fixes to Weaver WSP provider registration retry logic.

## Related Issue / Discussion


