### PR TITLE
DISCUSSION: proxy: add CORS headers to /twitcher/, affect all services behind it

### DIFF
--- a/birdhouse/config/twitcher/config/proxy/conf.extra-service.d/twitcher.conf.template
+++ b/birdhouse/config/twitcher/config/proxy/conf.extra-service.d/twitcher.conf.template
@@ -5,4 +5,6 @@
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host:$server_port;
         proxy_set_header Forwarded "proto=https;host=${PAVICS_FQDN_PUBLIC}";    # Helps the STAC component to craft URLs containing the full PAVICS_FQDN_PUBLIC
+
+        include /etc/nginx/conf.d/cors.include;
     }


### PR DESCRIPTION
## Overview

This PR is rather to start a discuss than ready to merge.  That's why there is no CHANGES.md update.

So I needed to add CORS allow headers for Thredds, so our partner javascript webapps running on other domains than pavics.ouranos.ca can hit our Thredds, so we act as the backend for their frontend.

1. Is adding the CORS header to Twitcher okay with you guys?  Because the new headers will affect all other services behind Twitcher.

2. By adding this CORS header, I lost the `X-Robots-Tag: noindex, nofollow` header (optional-components/x-robots-tag-header) !  Is that expected?  Or the way I add headers to Twitcher is wrong?  I was just doing the same thing as all the existing services.  The `X-Robots-Tag` header is important to avoid being hit by crawlers.

```
birdhouse/config/magpie/config/proxy/conf.extra-service.d/magpie.conf.template
5:        include /etc/nginx/conf.d/cors.include;

birdhouse/deprecated-components/ncwms2/config/proxy/conf.extra-service.d/ncwms2.conf.template
5:    #    include /etc/nginx/conf.d/cors.include;

birdhouse/components/cowbird/config/proxy/conf.extra-service.d/cowbird.conf.template
8:        include /etc/nginx/conf.d/cors.include;

birdhouse/components/weaver/config/proxy/conf.extra-service.d/weaver.conf.template
16:        include /etc/nginx/conf.d/cors.include;

birdhouse/components/stac/config/proxy/conf.extra-service.d/stac.conf.template
12:        include /etc/nginx/conf.d/cors.include;
```

3. Is our current CORS headers way too permissive?

This is what we return https://github.com/bird-house/birdhouse-deploy/blob/97ee8da24821391aeef52b13ea9adda28f919085/birdhouse/components/proxy/conf.d/cors.include
```
Access-Control-Allow-Origin: *                                                                                                                                                           
Access-Control-Allow-Methods: GET, POST, OPTIONS                                                                                                                                         
Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range
Access-Control-Expose-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range
```

This is already enough
```
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization
Access-Control-Allow-Methods: POST, GET, OPTIONS
```

I think perhaps we should not allow-origin * but a list of known partners domain?  And trim down the allow-headers list?

I am not security expert so I want to hear from you guys.

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.
  Note that using ``[skip ci]``, ``[ci skip]`` or ``[no ci]`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
