### PR TITLE
Adapt to the new xclim-testdata structure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,17 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- xclim-testdata: adapt repository cloning script to the new data structure
+
+  The `xclim-testdata` repo has been restructured to include the data in a `data` subdirectory.
+  This change updates the cloning script to account for this new structure and to ensure that the
+  user experience is consistent with the previous version.
+
+  See:
+  * [xclim-testdata PR/29](https://github.com/Ouranosinc/xclim-testdata/pull/29)
+  * [xclim PR/1889](https://github.com/Ouranosinc/xclim/pull/1889)
 
 [2.5.2](https://github.com/bird-house/birdhouse-deploy/tree/2.5.2) (2024-07-19)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/deployment/deploy-data-xclim-testdata-to-thredds.yml
+++ b/birdhouse/deployment/deploy-data-xclim-testdata-to-thredds.yml
@@ -5,7 +5,7 @@ deploy:
   checkout_name: xclim-testdata
   dir_maps:
   # rsync content below source_dir into dest_dir
-  - source_dir: .
+  - source_dir: ./data
     dest_dir: /data/datasets/testdata/xclim
     # only sync .nc files
     rsync_extra_opts: --include=*/ --include=*.nc --exclude=*


### PR DESCRIPTION
## Overview

This PR updates the cloning of the xclim-testdata repo to reflect structural changes.

## Changes

**Non-breaking changes**
- Adjusts the location of the xclim-testdata data folder

## Related Issue / Discussion

- https://github.com/Ouranosinc/xclim-testdata/pull/29
- https://github.com/Ouranosinc/xclim/pull/1889

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.
  Note that using ``[skip ci]``, ``[ci skip]`` or ``[no ci]`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
