### PR TITLE
Update PR template to avoid default regex self-match when copy-pasted to merge commit message

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,11 @@ Links to other issues or sources.
 <!--
   The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
   To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.
-  Note that using ``[skip ci]``, ``[ci skip]`` or ``[no ci]`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
+
+  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
+  Such commit command can be used to override the PR description behavior for a specific commit update.
+  However, a commit message cannot 'force run' a PR which the description turns off the CI.
+  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
 -->
 
 birdhouse_daccs_configs_branch: master


### PR DESCRIPTION
## Overview

Update PR template to avoid default regex self-match when copy-pasted to merge commit message.

Use roundabout comment description to avoid matching the regex.

## Changes

**Non-breaking changes**
- CI maintenance, PR template

**Breaking changes**
- n/a

## Related Issue / Discussion

- Fix PR not triggering CI.

## CI Operations


birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
