### PR TITLE
fix docs build invalid `intersphinx_mapping`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -357,4 +357,20 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('http://docs.python.org/', None),
+    'phoenix': ('https://pyramid-phoenix.readthedocs.io/en/latest/', None),
+    'malleefowl': ('https://malleefowl.readthedocs.io/en/latest/', None),
+    'weaver': ('https://pavics-weaver.readthedocs.io/en/latest/', None),
+    'magpie': ('https://pavics-magpie.readthedocs.io/en/latest/', None),
+    'twitcher': ('https://twitcher.readthedocs.io/en/latest/', None),
+    'flyingpigeon': ('https://flyingpigeon.readthedocs.io/en/latest/', None),
+    'hummingbird': ('https://birdhouse-hummingbird.readthedocs.io/en/latest/', None),
+    'finch': ('https://finch.readthedocs.io/en/latest/', None),
+    'raven': ('https://pavics-raven.readthedocs.io/en/latest/', None),
+    'emu': ('https://emu.readthedocs.io/en/latest/', None),
+    'pelican': ('https://github.com/bird-house/pelican', None),
+    'birdy': ('https://birdy.readthedocs.io/en/latest/', None),
+    'bootstrap': ('https://birdhousebuilderbootstrap.readthedocs.io/en/latest/', None),
+    'birdhouse-deploy': ('https://birdhouse-deploy.readthedocs.io/en/latest/', None),
+}


### PR DESCRIPTION
## Overview

Fix docs build invalid `intersphinx_mapping`.

## Changes

**Non-breaking changes**
- fix docs

**Breaking changes**
- n/a

## Additional Information


- Fix error as seen in https://readthedocs.org/projects/birdhouse-deploy/builds/25570203/

## CI Operations

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
