### PR TITLE
Fix help string description for `bin/birdhouse configs` command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,12 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- Fix help string description for `bin/birdhouse configs` command
+
+  Update description of the `configs` subcommand to better describe it.
+  The description when calling `bin/birdhouse -h` now matches the description when calling `bin/birdhouse configs -h`
 
 [2.6.0](https://github.com/bird-house/birdhouse-deploy/tree/2.6.0) (2024-11-19)
 ------------------------------------------------------------------------------------------------------------------

--- a/bin/birdhouse
+++ b/bin/birdhouse
@@ -15,7 +15,7 @@ Manage the Birdhouse software stack.
 Commands:
   info      Print build information
   compose   Run a \"docker compose\" command for the Birdhouse project
-  configs   Print a command that can be used to load configuration settings as environment variables
+  configs   Load or execute commands in the Birdhouse configuration environment
 
 Options:
   -h, --help                   Print this message and exit


### PR DESCRIPTION
## Overview

Update description of the `configs` subcommand to better describe it.
The description when calling `bin/birdhouse -h` now matches the description when calling `bin/birdhouse configs -h`

## Changes

**Non-breaking changes**
help string update

**Breaking changes**
None

## Related Issue / Discussion

https://github.com/bird-house/birdhouse-deploy/pull/478#discussion_r1852852846

## Additional Information

Links to other issues or sources.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
