### PR TITLE
Add resolver for http nginx configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,16 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Add resolver for http nginx configuration
+
+  Nginx requires a resolver to be explicity defined when using `proxy_pass` with a variable in the argument passed
+  to `proxy_pass`. This resolver is defined explicitly for the https server block but not for the http server block.
+
+  This adds the explicit resolver for the http server block as well so that `proxy_pass` works when called using using
+  http URLs as well.
+  
 
 [2.7.1](https://github.com/bird-house/birdhouse-deploy/tree/2.7.1) (2024-12-20)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/proxy/conf.d/frontend.conf.template
+++ b/birdhouse/components/proxy/conf.d/frontend.conf.template
@@ -18,6 +18,8 @@ server {
     listen       80;
     server_name  localhost;
 
+    resolver 127.0.0.11;
+
     ${PROXY_INCLUDE_FOR_PORT_80}
 
     # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
## Overview
Nginx requires a resolver to be explicity defined when using `proxy_pass` with a variable in the argument passed to `proxy_pass`. This resolver is defined explicitly for the https server block but not for the http server block.

This adds the explicit resolver for the http server block as well so that `proxy_pass` works when called using using http URLs as well.


## Changes

**Non-breaking changes**
- Bug fix (only relevant for http URLs, ie. non-production environments)

**Breaking changes**
- None

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
