### PR TITLE
deprecate docker-compose default command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,14 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- Deprecate the `docker-compose` command as default
+
+  Sets the default compose command to `docker compose` using the new `DOCKER_COMPOSE` environment variable.
+  This uses compose v2 by default (instead of v1 which is very old and has been deprecated for a while).
+  For backwards compatibility, you can set `DOCKER_COMPOSE=docker-compose` in the local environment file to 
+  use the previous default.
 
 [2.10.0](https://github.com/bird-house/birdhouse-deploy/tree/2.10.0) (2025-02-24)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/birdhouse-compose.sh
+++ b/birdhouse/birdhouse-compose.sh
@@ -135,7 +135,7 @@ fi
 
 log INFO "Executing docker-compose with extra options: $* ${COMPOSE_EXTRA_OPTS}"
 # the PROXY_HTTP_PORT is a little trick to make the compose file invalid without the usage of this wrapper script
-PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} docker-compose ${COMPOSE_CONF_LIST} $* ${COMPOSE_EXTRA_OPTS}
+PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} ${DOCKER_COMPOSE} ${COMPOSE_CONF_LIST} $* ${COMPOSE_EXTRA_OPTS}
 ERR=$?
 if [ ${ERR} -gt 0 ]; then
   log ERROR "docker-compose error, exit code ${ERR}"
@@ -155,11 +155,11 @@ while [ $# -gt 0 ]
 do
   if [ x"$1" = x"up" ]; then
     # we restart the proxy after an up to make sure nginx continue to work if any container IP address changes
-    PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} docker-compose ${COMPOSE_CONF_LIST} restart proxy
+    PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} ${DOCKER_COMPOSE} ${COMPOSE_CONF_LIST} restart proxy
 
     # run postgres post-startup setup script
     # Note: this must run before the post-docker-compose-up scripts since some may expect postgres databases to exist
-    postgres_id=$(PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} docker-compose ${COMPOSE_CONF_LIST} ps -q postgres 2> /dev/null)
+    postgres_id=$(PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} ${DOCKER_COMPOSE} ${COMPOSE_CONF_LIST} ps -q postgres 2> /dev/null)
     if [ ! -z "$postgres_id" ]; then
       docker exec ${postgres_id} /postgres-setup.sh
     fi

--- a/birdhouse/components/scheduler/default.env
+++ b/birdhouse/components/scheduler/default.env
@@ -19,6 +19,11 @@ export BIRDHOUSE_AUTODEPLOY_NOTEBOOK_FREQUENCY="@hourly"
 
 export BIRDHOUSE_LOGROTATE_DATA_DIR='${BIRDHOUSE_DATA_PERSIST_ROOT}/logrotate'
 
+# The old version of docker-compose is required so that the same command can be run inside the
+# autodeploy image as the command that is run on the host machine.
+# TODO: update the autodeploy image so that this is not necessary.
+export DOCKER_COMPOSE=docker-compose
+
 export DELAYED_EVAL="
   $DELAYED_EVAL
   BIRDHOUSE_LOGROTATE_DATA_DIR

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -202,3 +202,8 @@ export USER_WORKSPACE_UID=1000
 export USER_WORKSPACE_GID=1000
 
 export BIRDHOUSE_WPS_OUTPUTS_DIR='${BIRDHOUSE_DATA_PERSIST_SHARED_ROOT}/wps_outputs'
+
+# Sets the command to run in order to execute docker compose commands. If you are using a
+# (very very) old version of docker you may need to override this in the local environment file
+# as 'docker-compose'.
+export DOCKER_COMPOSE='docker compose'

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -673,6 +673,12 @@ export PHOENIX_PASSWORD_HASH="${__DEFAULT__PHOENIX_PASSWORD_HASH}"
 #   https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
 #############################################################################
 
+# Sets the command to run in order to execute docker compose commands. If you are using a
+# (very very) old version of docker you may need to override this in the local environment file
+# as 'docker-compose'.
+#export DOCKER_COMPOSE='docker compose'
+
+
 # Remove orphans containers, useful when disabling components.
 # Harmless when left enabled all the time.
 # Not working at the time of this writing, see https://github.com/docker/compose/issues/11374.

--- a/birdhouse/optional-components/local-dev-test/pre-docker-compose-up.include
+++ b/birdhouse/optional-components/local-dev-test/pre-docker-compose-up.include
@@ -18,7 +18,7 @@ THIS_COMPOSE_FILE="${COMPOSE_DIR}/optional-components/local-dev-test/docker-comp
 echo 'version: "3.4"' > "${THIS_COMPOSE_FILE}"
 echo "services:" >> "${THIS_COMPOSE_FILE}"
 
-for service in $(PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} docker-compose ${COMPOSE_CONF_LIST} config --services 2> /dev/null); do
+for service in $(PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} ${DOCKER_COMPOSE} ${COMPOSE_CONF_LIST} config --services 2> /dev/null); do
     printf ' %s:\n  extra_hosts:\n   - "host.docker.internal:host-gateway"\n' $service >> "${THIS_COMPOSE_FILE}"
 done
 


### PR DESCRIPTION
## Overview

Sets the default compose command to `docker compose` using the new `DOCKER_COMPOSE` environment variable. This uses compose v2 by default (instead of v1 which is very old and has been deprecated for a while). For backwards compatibility, you can set `DOCKER_COMPOSE=docker-compose` in the local environment file to use the previous default.

## Changes

**Non-breaking changes**

**Breaking changes**
- If you do not have a version of docker that has a compose subcommand, you will have to set `DOCKER_COMPOSE=docker-compose` in env.local

## Related Issue / Discussion

## Additional Information

This means that new installations will not need to download a separate `docker-compose` binary.

Links to other issues or sources.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
