### PR TITLE
Remove compose v1 syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,23 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+# Changes
+
+- Update Docker Compose syntax to version 2 in all docker compose files
+
+  The version 1 compose specification that docker uses is out of date and no longer maintained by docker.
+  We currently have a mix of version 1 syntax and version 2 (specifically 2.20.2+) syntax in our docker compose
+  files.
+
+  This means that the stack will not properly run with a docker compose version <2.20.2. For any version >2.20.2 
+  the stack runs properly but displays lots of deprecation warnings about deprecated version strings and external
+  volume and network definitions.
+
+  This PR updates all version 1 syntax so that these deprecation warnings are not displayed. Documentation has 
+  been updated to make this dependency on a modern version of docker explicit.
+
+  **Breaking Change**: as of birdhouse-deploy version 2.7.3, the stack could not be deployed with a docker compose
+  version <2.20.2. However, that was not specified in the release notes so we're stating it here.
 
 [2.10.1](https://github.com/bird-house/birdhouse-deploy/tree/2.10.1) (2025-03-10)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/README.rst
+++ b/birdhouse/README.rst
@@ -15,8 +15,15 @@ Requirements
 * User running ``BIRDHOUSE_COMPOSE`` below must not be ``root`` but a regular user
   belonging to the ``docker`` group.
 
-* Install latest docker-ce and docker-compose for the chosen distro (not the
-  version from the distro).
+* `Install latest version of docker <https://docs.docker.com/engine/install/>`_ for the chosen distro 
+   (not the version from the distro).
+
+  * Please ensure the latest versions of the following packages and any of their dependencies
+    are installed for your distro:
+
+    * docker engine
+    * docker CLI
+    * docker compose plugin (v2.20.2+ is required)
   
 * Have a real SSL Certificate, self-signed SSL Certificate do not work properly.
   Let's Encrypt offers free SSL Certificate.

--- a/birdhouse/components/canarie-api/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/canarie-api/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/cowbird/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/cowbird/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   canarie-api: &canarie-volumes

--- a/birdhouse/components/cowbird/config/geoserver/docker-compose-extra.yml
+++ b/birdhouse/components/cowbird/config/geoserver/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   cowbird:

--- a/birdhouse/components/cowbird/config/jupyterhub/docker-compose-extra.yml
+++ b/birdhouse/components/cowbird/config/jupyterhub/docker-compose-extra.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   cowbird:
     environment:

--- a/birdhouse/components/cowbird/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/cowbird/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   # extend Magpie permissions to grant access to Cowbird API via secured Twitcher proxy

--- a/birdhouse/components/cowbird/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/cowbird/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   # extend proxy with endpoint and config for Cowbird API access

--- a/birdhouse/components/cowbird/docker-compose-extra.yml
+++ b/birdhouse/components/cowbird/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/data-volume/docker-compose-extra.yml
+++ b/birdhouse/components/data-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 volumes:
   data: {}

--- a/birdhouse/components/finch/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/finch/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/finch/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/finch/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/components/finch/config/wps_outputs-volume/docker-compose-extra.yml
+++ b/birdhouse/components/finch/config/wps_outputs-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   finch:

--- a/birdhouse/components/finch/docker-compose-extra.yml
+++ b/birdhouse/components/finch/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/geoserver/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/geoserver/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/geoserver/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/geoserver/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/components/geoserver/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/geoserver/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/geoserver/docker-compose-extra.yml
+++ b/birdhouse/components/geoserver/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/hummingbird/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/hummingbird/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/hummingbird/config/data-volume/docker-compose-extra.yml
+++ b/birdhouse/components/hummingbird/config/data-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   hummingbird:

--- a/birdhouse/components/hummingbird/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/hummingbird/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/components/hummingbird/config/wps_outputs-volume/docker-compose-extra.yml
+++ b/birdhouse/components/hummingbird/config/wps_outputs-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   hummingbird:

--- a/birdhouse/components/hummingbird/docker-compose-extra.yml
+++ b/birdhouse/components/hummingbird/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/jupyterhub/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/jupyterhub/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/jupyterhub/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/jupyterhub/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/components/jupyterhub/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/jupyterhub/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/jupyterhub/docker-compose-extra.yml
+++ b/birdhouse/components/jupyterhub/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging
@@ -57,10 +56,10 @@ services:
 # need external network so the folder name is not prefixed to network name
 networks:
   jupyterhub_network:
-    external:
-      name: "jupyterhub_network"
+    name: "jupyterhub_network"
+    external: true
 
 volumes:
   jupyterhub_data_persistence:
-    external:
-      name: jupyterhub_data_persistence
+    name: jupyterhub_data_persistence
+    external: true

--- a/birdhouse/components/magpie/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/magpie/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/magpie/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/magpie/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/mongodb/docker-compose-extra.yml
+++ b/birdhouse/components/mongodb/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/monitoring/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/monitoring/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   magpie:

--- a/birdhouse/components/monitoring/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/monitoring/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   proxy:

--- a/birdhouse/components/monitoring/docker-compose-extra.yml
+++ b/birdhouse/components/monitoring/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   # https://github.com/google/cadvisor/blob/master/docs/running.md
@@ -123,13 +122,13 @@ services:
 
 volumes:
   prometheus_persistence:
-    external:
-      name: prometheus_persistence
+    external: true
+    name: prometheus_persistence
   grafana_persistence:
-    external:
-      name: grafana_persistence
+    external: true
+    name: grafana_persistence
   alertmanager_persistence:
-    external:
-      name: alertmanager_persistence
+    external: true
+    name: alertmanager_persistence
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/components/portainer/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/portainer/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/portainer/docker-compose-extra.yml
+++ b/birdhouse/components/portainer/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/postgres/docker-compose-extra.yml
+++ b/birdhouse/components/postgres/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/proxy/docker-compose-ssl-cert.yml
+++ b/birdhouse/components/proxy/docker-compose-ssl-cert.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   proxy:

--- a/birdhouse/components/raven/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/raven/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/raven/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/raven/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/components/raven/config/wps_outputs-volume/docker-compose-extra.yml
+++ b/birdhouse/components/raven/config/wps_outputs-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   raven:

--- a/birdhouse/components/raven/docker-compose-extra.yml
+++ b/birdhouse/components/raven/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/scheduler/config/jupyterhub/docker-compose-extra.yml
+++ b/birdhouse/components/scheduler/config/jupyterhub/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   scheduler:

--- a/birdhouse/components/scheduler/docker-compose-extra.yml
+++ b/birdhouse/components/scheduler/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   scheduler:
@@ -10,7 +9,7 @@ services:
     environment:
       COMPOSE_DIR: ${PWD}
       BIRDHOUSE_AUTODEPLOY_DEPLOY_KEY_ROOT_DIR: ${BIRDHOUSE_AUTODEPLOY_DEPLOY_KEY_ROOT_DIR}
-      CODE_OWNERSHIP: ${BIRDHOUSE_AUTODEPLOY_CODE_OWNERSHIP}
+      CODE_OWNERSHIP: ${BIRDHOUSE_AUTODEPLOY_CODE_OWNERSHIP:-}
     restart: always
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/birdhouse/components/stac/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/stac/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/stac/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/stac/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   magpie:

--- a/birdhouse/components/stac/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/stac/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/stac/config/twitcher/docker-compose-extra.yml
+++ b/birdhouse/components/stac/config/twitcher/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   # extend twitcher with MagpieAdapter hooks employed for STAC proxied requests

--- a/birdhouse/components/stac/docker-compose-extra.yml
+++ b/birdhouse/components/stac/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/thredds/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/thredds/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/thredds/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/thredds/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/components/thredds/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/thredds/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/thredds/docker-compose-extra.yml
+++ b/birdhouse/components/thredds/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging: &default-logging
   driver: "json-file"
@@ -44,5 +43,5 @@ services:
       
 volumes:
   thredds_persistence:
-    external:
-      name: thredds_persistence
+    external: true
+    name: thredds_persistence

--- a/birdhouse/components/twitcher/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/twitcher/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/twitcher/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/twitcher/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/twitcher/docker-compose-extra.yml
+++ b/birdhouse/components/twitcher/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/weaver/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   # extend proxy configuration with weaver endpoints

--- a/birdhouse/components/weaver/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   # extend magpie configuration with setup of weaver service and initial permissions
@@ -10,4 +9,3 @@ services:
       #   config files for each extendable service, using loading of all configuration files found in mount directories.
       - ./components/weaver/config/magpie/config.yml:${MAGPIE_PERMISSIONS_CONFIG_PATH}/weaver-permissions.yml:ro
       - ./components/weaver/config/magpie/config.yml:${MAGPIE_PROVIDERS_CONFIG_PATH}/weaver-providers.yml:ro
-

--- a/birdhouse/components/weaver/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   # extend proxy configuration with weaver endpoints

--- a/birdhouse/components/weaver/config/twitcher/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/config/twitcher/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   # extend twitcher with MagpieAdapter hooks employed for weaver proxied requests

--- a/birdhouse/components/weaver/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/components/wps_outputs-volume/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/components/wps_outputs-volume/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/components/wps_outputs-volume/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/wps_outputs-volume/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/components/wps_outputs-volume/docker-compose-extra.yml
+++ b/birdhouse/components/wps_outputs-volume/docker-compose-extra.yml
@@ -1,6 +1,3 @@
-version: "3.4"
 
 volumes:
   wps_outputs: {}
-
-

--- a/birdhouse/deprecated-components/catalog/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/catalog/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/deprecated-components/catalog/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/catalog/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/deprecated-components/catalog/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/catalog/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/deprecated-components/flyingpigeon/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/flyingpigeon/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/deprecated-components/flyingpigeon/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/flyingpigeon/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/deprecated-components/flyingpigeon/config/wps_outputs-volume/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/flyingpigeon/config/wps_outputs-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   flyingpigeon:

--- a/birdhouse/deprecated-components/flyingpigeon/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/flyingpigeon/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/deprecated-components/frontend/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/frontend/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/deprecated-components/frontend/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/frontend/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/deprecated-components/frontend/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/frontend/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/deprecated-components/malleefowl/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/malleefowl/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/deprecated-components/malleefowl/config/data-volume/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/malleefowl/config/data-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   malleefowl:

--- a/birdhouse/deprecated-components/malleefowl/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/malleefowl/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/deprecated-components/malleefowl/config/wps_outputs-volume/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/malleefowl/config/wps_outputs-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   malleefowl:

--- a/birdhouse/deprecated-components/malleefowl/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/malleefowl/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging: &default-logging
   driver: "json-file"

--- a/birdhouse/deprecated-components/ncwms2/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/ncwms2/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/deprecated-components/ncwms2/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/ncwms2/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/deprecated-components/ncwms2/config/wps_outputs-volume/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/ncwms2/config/wps_outputs-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   ncwms2:

--- a/birdhouse/deprecated-components/ncwms2/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/ncwms2/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging: &default-logging
   driver: "json-file"

--- a/birdhouse/deprecated-components/phoenix/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/phoenix/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/deprecated-components/phoenix/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/phoenix/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/deprecated-components/project-api/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/project-api/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/deprecated-components/project-api/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/project-api/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/deprecated-components/project-api/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/project-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/deprecated-components/solr/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/solr/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/deprecated-components/solr/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/solr/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/deprecated-components/wps-healthchecks/config/catalog/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/wps-healthchecks/config/catalog/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   catalog:
     healthcheck:

--- a/birdhouse/deprecated-components/wps-healthchecks/config/flyingpigeon/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/wps-healthchecks/config/flyingpigeon/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   flyingpigeon:
     healthcheck:

--- a/birdhouse/deprecated-components/wps-healthchecks/config/malleefowl/docker-compose-extra.yml
+++ b/birdhouse/deprecated-components/wps-healthchecks/config/malleefowl/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   malleefowl:
     healthcheck:

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -1,3 +1,2 @@
-version: "3.4"
 
 services: {} # no services loaded by default

--- a/birdhouse/optional-components/all-public-access/config/catalog/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/catalog/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/finch/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/finch/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/flyingpigeon/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/flyingpigeon/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/geoserver/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/geoserver/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/hummingbird/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/hummingbird/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/jupyterhub/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/jupyterhub/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/malleefowl/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/malleefowl/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/ncwms2/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/ncwms2/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/raven/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/raven/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/secure-data-proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/secure-data-proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/all-public-access/config/thredds/docker-compose-extra.yml
+++ b/birdhouse/optional-components/all-public-access/config/thredds/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/backwards-compatible-overrides/config/jupyterhub/docker-compose-extra.yml
+++ b/birdhouse/optional-components/backwards-compatible-overrides/config/jupyterhub/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   jupyterhub:
     environment:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/catalog/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/catalog/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/cowbird/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/cowbird/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/finch/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/finch/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/hummingbird/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/hummingbird/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/malleefowl/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/malleefowl/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/ncwms2/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/ncwms2/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/raven/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/raven/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/thredds/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/thredds/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/canarie-api-full-monitoring/config/weaver/docker-compose-extra.yml
+++ b/birdhouse/optional-components/canarie-api-full-monitoring/config/weaver/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/database-external-ports/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/optional-components/database-external-ports/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   postgres-magpie:
     ports:

--- a/birdhouse/optional-components/database-external-ports/config/mongodb/docker-compose-extra.yml
+++ b/birdhouse/optional-components/database-external-ports/config/mongodb/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   mongodb:
     ports:

--- a/birdhouse/optional-components/database-external-ports/config/postgres/docker-compose-extra.yml
+++ b/birdhouse/optional-components/database-external-ports/config/postgres/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   postgres:
     ports:

--- a/birdhouse/optional-components/emu/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/optional-components/emu/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/emu/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/optional-components/emu/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/emu/docker-compose-extra.yml
+++ b/birdhouse/optional-components/emu/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   emu:
     image: ${EMU_IMAGE}

--- a/birdhouse/optional-components/generic_bird/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/optional-components/generic_bird/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/generic_bird/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/optional-components/generic_bird/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/generic_bird/config/wps_outputs-volume/docker-compose-extra.yml
+++ b/birdhouse/optional-components/generic_bird/config/wps_outputs-volume/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   generic_bird:

--- a/birdhouse/optional-components/generic_bird/docker-compose-extra.yml
+++ b/birdhouse/optional-components/generic_bird/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   generic_bird:
     image: ${GENERIC_BIRD_IMAGE}

--- a/birdhouse/optional-components/prometheus-log-parser/config/monitoring/docker-compose-extra.yml
+++ b/birdhouse/optional-components/prometheus-log-parser/config/monitoring/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   prometheus:
     volumes:

--- a/birdhouse/optional-components/prometheus-log-parser/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/prometheus-log-parser/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/optional-components/prometheus-log-parser/config/thredds/docker-compose-extra.yml
+++ b/birdhouse/optional-components/prometheus-log-parser/config/thredds/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   prometheus-log-parser:
     volumes:

--- a/birdhouse/optional-components/prometheus-log-parser/docker-compose-extra.yml
+++ b/birdhouse/optional-components/prometheus-log-parser/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging: &default-logging
   driver: "json-file"

--- a/birdhouse/optional-components/prometheus-longterm-metrics/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/optional-components/prometheus-longterm-metrics/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   magpie:

--- a/birdhouse/optional-components/prometheus-longterm-metrics/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/prometheus-longterm-metrics/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   proxy:

--- a/birdhouse/optional-components/prometheus-longterm-metrics/docker-compose-extra.yml
+++ b/birdhouse/optional-components/prometheus-longterm-metrics/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/optional-components/prometheus-longterm-rules/config/monitoring/docker-compose-extra.yml
+++ b/birdhouse/optional-components/prometheus-longterm-rules/config/monitoring/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   prometheus:

--- a/birdhouse/optional-components/secure-data-proxy/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/optional-components/secure-data-proxy/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/secure-data-proxy/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/secure-data-proxy/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/optional-components/secure-thredds/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/optional-components/secure-thredds/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/stac-data-proxy/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/stac-data-proxy/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/optional-components/stac-data-proxy/config/secure-data-proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/stac-data-proxy/config/secure-data-proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/stac-populator/docker-compose-extra.yml
+++ b/birdhouse/optional-components/stac-populator/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/optional-components/stac-public-access/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/optional-components/stac-public-access/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/stac-public-access/config/stac-data-proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/stac-public-access/config/stac-data-proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/test-cowbird-jupyter-access/docker-compose-extra.yml
+++ b/birdhouse/optional-components/test-cowbird-jupyter-access/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   jupyterhub:
     environment:

--- a/birdhouse/optional-components/test-geoserver-secured-access/docker-compose-extra.yml
+++ b/birdhouse/optional-components/test-geoserver-secured-access/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/test-weaver/docker-compose-extra.yml
+++ b/birdhouse/optional-components/test-weaver/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   magpie:
     volumes:

--- a/birdhouse/optional-components/testthredds/config/canarie-api/docker-compose-extra.yml
+++ b/birdhouse/optional-components/testthredds/config/canarie-api/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   canarie-api: &canarie-volumes
     volumes:

--- a/birdhouse/optional-components/testthredds/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/testthredds/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/optional-components/testthredds/docker-compose-extra.yml
+++ b/birdhouse/optional-components/testthredds/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   testthredds:
     image: ${TESTTHREDDS_IMAGE}

--- a/birdhouse/optional-components/thanos/config/magpie/docker-compose-extra.yml
+++ b/birdhouse/optional-components/thanos/config/magpie/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   magpie:

--- a/birdhouse/optional-components/thanos/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/thanos/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 services:
   proxy:

--- a/birdhouse/optional-components/thanos/docker-compose-extra.yml
+++ b/birdhouse/optional-components/thanos/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 
 x-logging:
   &default-logging

--- a/birdhouse/optional-components/x-robots-tag-header/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/optional-components/x-robots-tag-header/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     volumes:

--- a/birdhouse/vagrant-utils/install-docker.sh
+++ b/birdhouse/vagrant-utils/install-docker.sh
@@ -102,6 +102,7 @@ echo 'export PATH="$PATH:/usr/local/bin"' | sudo tee /etc/profile.d/usr_local_pa
 # Pin docker-compose to a specific version to match autodeploy version of
 # docker-compose.  Otherwise, alternating between the different versions will
 # keep recreating all the containers for no reasons.
+# TODO: this no longer works for versions of birdhouse deploy >2.7.3... update this and the autodeploy job to require docker compose version 2.20.2+
 LATEST_COMPOSE_VERSION="1.26.2"
 sudo curl -L "https://github.com/docker/compose/releases/download/$LATEST_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
## Overview

The version 1 compose specification that docker uses is out of date and no longer maintained by docker.
We currently have a mix of version 1 syntax and version 2 (specifically 2.20.2+) syntax in our docker compose files.

This means that the stack will not properly run with a docker compose version <2.20.2. For any version >2.20.2 the stack runs properly but displays lots of deprecation warnings about deprecated version strings and external volume and network definitions.

This PR updates all version 1 syntax so that these deprecation warnings are not displayed. Documentation has been updated to make this dependency on a modern version of docker explicit.

**Breaking Change**: as of birdhouse-deploy version 2.7.3, the stack could not be deployed with a docker compose version <2.20.2. However, that was not specified in the release notes so we're stating it here.

## Changes

**Non-breaking changes**
- None

**Breaking changes**

- None but this documents a previous breaking change that occurred in version 2.7.3 for deployments using a docker compose version <2.20.2 

## Related Issue / Discussion

## Additional Information

@tlvu I think you'll be especially interested in this

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
