### PR TITLE
remove deprecated catalog crawler code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,14 @@
   For backwards compatibility, you can set `DOCKER_COMPOSE=docker-compose` in the local environment file to 
   use the previous default.
 
+- Remove deprecated catalog crawler code
+
+  Code related to the solr catalog in the `birdhouse-compose.sh` file has been deprecated for a while and 
+  is not currently usable with the current stack anyway so it is removed
+
+  Also there is commented out old code that relates to the presence of an SSL certificate which is not use 
+  and no longer relevant as of version 2.7.0.
+
 [2.10.1](https://github.com/bird-house/birdhouse-deploy/tree/2.10.1) (2025-03-10)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/birdhouse/birdhouse-compose.sh
+++ b/birdhouse/birdhouse-compose.sh
@@ -67,21 +67,6 @@ read_configs # this sets ALL_CONF_DIRS
 
 check_required_vars || exit $?
 
-## check fails when root access is required to access this file.. workaround possible by going through docker daemon... but
-# will add delay
-# if [ ! -f $BIRDHOUSE_SSL_CERTIFICATE ]
-# then
-#   log ERROR "SSL certificate file $BIRDHOUSE_SSL_CERTIFICATE is missing"
-#   exit 1
-# fi
-
-TIMEWAIT_REUSE=$(/sbin/sysctl -n  net.ipv4.tcp_tw_reuse)
-if [ "${TIMEWAIT_REUSE}" -eq 0 ]
-then
-  log WARN "the sysctl net.ipv4.tcp_tw_reuse is not enabled. " \
-       "It it suggested to set it to 1, otherwise the birdhousecrawler may fail."
-fi
-
 export BIRDHOUSE_AUTODEPLOY_EXTRA_REPOS_AS_DOCKER_VOLUMES=""
 for adir in ${BIRDHOUSE_AUTODEPLOY_EXTRA_REPOS}; do
   # 4 spaces in front of '--volume' is important


### PR DESCRIPTION
## Overview

Code related to the solr catalog in the `birdhouse-compose.sh` file has been deprecated for a while and is not currently usable with the current stack anyway so it is removed

Also there is commented out old code that relates to the presence of an SSL certificate which is not use and no longer relevant as of version [2.7.0](https://github.com/bird-house/birdhouse-deploy/releases/tag/2.7.0).

## Changes

**Non-breaking changes**
- cleanup unused code

**Breaking changes**
- None

## Related Issue / Discussion


## Additional Information

Links to other issues or sources.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
