### PR TITLE
improved template file generation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,8 +19,9 @@
 
 - Improve handling of `.template` files generation
 
+  * Change the templating mechanism to run by default for the docker compose `restart` command instead of only `up`.
   * Add `BIRDHOUSE_COMPOSE_TEMPLATE_FORCE` variable that allows enforcing the generation of the `.template` files
-    instead of only when compose `up` command is passed by default.
+    instead of only when compose `up` or `restart` command is passed by default.
   * Add automatic removal of empty directories conflicting with `.template` destinations. 
     This occurs only if a `docker compose` command ran early, and it generated volume mount directories to the
     yet non-existing files.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
 
 - Improve handling of `.template` files generation
 
-  * Add `BIRDHOUSE_COMPOSE_TEMPLATE_FORCE` variable that allows enforing the generation of the `.template` files
+  * Add `BIRDHOUSE_COMPOSE_TEMPLATE_FORCE` variable that allows enforcing the generation of the `.template` files
     instead of only when compose `up` command is passed by default.
   * Add automatic removal of empty directories conflicting with `.template` destinations. 
     This occurs only if a `docker compose` command ran early, and it generated volume mount directories to the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,15 @@
 
 ## Changes
 
+- Improve handling of `.template` files generation
+
+  * Add `BIRDHOUSE_COMPOSE_TEMPLATE_FORCE` variable that allows enforing the generation of the `.template` files
+    instead of only when compose `up` command is passed by default.
+  * Add automatic removal of empty directories conflicting with `.template` destinations. 
+    This occurs only if a `docker compose` command ran early, and it generated volume mount directories to the
+    yet non-existing files.
+  * Add logs when template generation occurs, is skipped, or edge case directories are removed.
+
 - Deprecate the `docker-compose` command as default
 
   Sets the default compose command to `docker compose` using the new `DOCKER_COMPOSE` environment variable.

--- a/birdhouse/birdhouse-compose.sh
+++ b/birdhouse/birdhouse-compose.sh
@@ -76,7 +76,7 @@ done
 export BIRDHOUSE_AUTODEPLOY_EXTRA_REPOS_AS_DOCKER_VOLUMES
 
 # we apply all the templates
-if [ x"$1" = x"up" ] || [ x"${BIRDHOUSE_COMPOSE_TEMPLATE_FORCE}" = x"true" ]; then
+if [ x"$1" = x"up" ] || [ x"$1" = x"restart" ] || [ x"${BIRDHOUSE_COMPOSE_TEMPLATE_FORCE}" = x"true" ]; then
   log INFO "Updating template files found across 'BIRDHOUSE_EXTRA_CONF_DIRS' (enabled and default components)."
   find ${ALL_CONF_DIRS} -name '*.template' 2>/dev/null |
   while read FILE
@@ -97,7 +97,7 @@ if [ x"$1" = x"up" ] || [ x"${BIRDHOUSE_COMPOSE_TEMPLATE_FORCE}" = x"true" ]; th
   done
   [ "$?" -eq 1 ] && exit 1  # re-raise the subshell error of the while loop
 else
-  log DEBUG "Skipping template files update (\"$1\" not \"up\" and not forced by BIRDHOUSE_COMPOSE_TEMPLATE_FORCE)"
+  log DEBUG "Skipping template files update (\"$1\" not \"up\", \"restart\", or forced by BIRDHOUSE_COMPOSE_TEMPLATE_FORCE)"
 fi
 
 SHELL_EXEC_FLAGS=

--- a/birdhouse/birdhouse-compose.sh
+++ b/birdhouse/birdhouse-compose.sh
@@ -76,7 +76,6 @@ done
 export BIRDHOUSE_AUTODEPLOY_EXTRA_REPOS_AS_DOCKER_VOLUMES
 
 # we apply all the templates
-BIRDHOUSE_COMPOSE_TEMPLATE_FORCE="${BIRDHOUSE_COMPOSE_TEMPLATE_FORCE:-false}"
 if [ x"$1" = x"up" ] || [ x"${BIRDHOUSE_COMPOSE_TEMPLATE_FORCE}" = x"true" ]; then
   log INFO "Updating template files found across 'BIRDHOUSE_EXTRA_CONF_DIRS' (enabled and default components)."
   find ${ALL_CONF_DIRS} -name '*.template' 2>/dev/null |
@@ -96,6 +95,7 @@ if [ x"$1" = x"up" ] || [ x"${BIRDHOUSE_COMPOSE_TEMPLATE_FORCE}" = x"true" ]; th
     fi
     cat "${FILE}" | envsubst "$VARS" | envsubst "$OPTIONAL_VARS" > "${DEST}"
   done
+  [ "$?" -eq 1 ] && exit 1  # re-raise the subshell error of the while loop
 else
   log DEBUG "Skipping template files update (\"$1\" not \"up\" and not forced by BIRDHOUSE_COMPOSE_TEMPLATE_FORCE)"
 fi

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -172,6 +172,10 @@ BIRDHOUSE_BACKWARDS_COMPATIBLE_VARIABLES="
 
 "
 
+# Enforce the regeneration of '.template' files for any docker compose commands.
+# By default, only the 'up' command triggers the operation.
+BIRDHOUSE_COMPOSE_TEMPLATE_FORCE="${BIRDHOUSE_COMPOSE_TEMPLATE_FORCE:-false}"
+
 # Process only these backwards compatible variables before the components default.env files are processed
 BIRDHOUSE_BACKWARDS_COMPATIBLE_VARIABLES_PRE_COMPONENTS="
     EXTRA_CONF_DIRS

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -173,7 +173,7 @@ BIRDHOUSE_BACKWARDS_COMPATIBLE_VARIABLES="
 "
 
 # Enforce the regeneration of '.template' files for any docker compose commands.
-# By default, only the 'up' command triggers the operation.
+# By default, only the 'up' and 'restart' command triggers the operation.
 BIRDHOUSE_COMPOSE_TEMPLATE_FORCE="${BIRDHOUSE_COMPOSE_TEMPLATE_FORCE:-false}"
 
 # Process only these backwards compatible variables before the components default.env files are processed


### PR DESCRIPTION
## Overview

Handle template generation with more lenient error handling and allow override when they occur.

## Changes

**Non-breaking changes**
- Improve handling of `.template` files generation

  * Add `BIRDHOUSE_COMPOSE_TEMPLATE_FORCE` variable that allows enforcing the generation of the `.template` files
    instead of only when compose `up` command is passed by default.
  * Add automatic removal of empty directories conflicting with `.template` destinations. 
    This occurs only if a `docker compose` command ran early, and it generated volume mount directories to the
    yet non-existing files.
  * Add logs when template generation occurs, is skipped, or edge case directories are removed.

**Breaking changes**
- n/a

## Related Issue / Discussion

- Resolves https://github.com/bird-house/birdhouse-deploy/issues/508

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
