### PR TITLE
Patch the header that displays weirdly in the generated docs

### DIFF
--- a/birdhouse/README.rst
+++ b/birdhouse/README.rst
@@ -156,8 +156,8 @@ Disk: at least 100 TB, depending how much data is hosted on Thredds and Geoserve
 In general, the more users, the more cpu cores and memory needed.  The more data, more memory and bigger and faster disks needed.
 
 
-Note
-----
+Note about WPS request timeout
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * All WPS requests should be completed within ``proxy_read_timeout`` of the
   Nginx proxy, see `nginx.conf`_ (:download:`download <birdhouse/components/proxy/nginx.conf>`).


### PR DESCRIPTION
## Overview

See the "Note" heading in the TOC under 
https://birdhouse-deploy.readthedocs.io/en/latest/deployment.html#deployment

![{D7320780-499F-4AC5-AE19-27653FD43569}](https://github.com/user-attachments/assets/763439a9-1b17-40db-84c3-e7162c8ca8ff)


## Changes

**Non-breaking changes**
- Patch the header that displays weirdly in the generated docs

**Breaking changes**
- n/a

## Related Issue / Discussion

- n/a

## CI Operations


birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
