### PR TITLE
remove `$` from logged error variable

### DIFF
--- a/birdhouse/read-configs.include.sh
+++ b/birdhouse/read-configs.include.sh
@@ -340,7 +340,7 @@ check_required_vars() {
         v="${i}"
         if [ -z "`eval "echo ${v}"`" ]
         then
-            log ERROR "Required variable $v is not set. Check env.local file."
+            log ERROR "Required variable ${v#$} is not set. Check env.local file."
             return 1
         fi
     done


### PR DESCRIPTION
## Overview

Logged errors in case of required variable include a `$`, leading to this kind of display: 

```sh
ERROR:    Required variable $ALERTMANAGER_SMTP_SERVER is not set. Check env.local file.
```

This gives the impression that something was not parsed or interpreted correctly. 

## Changes

**Non-breaking changes**
- remove the prefixed `$` from the variable in the log message, if any is applied, as in the case of `VAR` definitions having literal `$<VAR>`.

**Breaking changes**
- n/a

## Related Issue / Discussion

- Relates to https://github.com/bird-house/birdhouse-deploy/issues/514


## CI Operations

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
