### PR TITLE
Fix bug where compose directory can't be found in `bin/birdhouse` script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,21 @@
       those docker compose files as well so that you aren't bombarded by deprecation warnings whenever you start
       the birdhouse stack.  
 
+## Fixes
+
+  - Fix bug where compose directory can't be found in `bin/birdhouse` script
+
+    The `COMPOSE_DIR` variable cannnot be discovered properly if:
+    
+    - the `bin/birdhouse` script is called from with the `configs --print-config-command` options.
+    - the result of that call is `eval`ed in order to load the birdhouse configuration settings into 
+      the calling process's environment.
+    - this is done from a directory outside of the birdhouse-deploy source code directory.
+
+    This is fixed by explicitly giving a value for the `COMPOSE_DIR` variable when using the `--print-config-command`
+    option. The value is already correctly set in the `bin/birdhouse` script so it is easy to pass that 
+    value on to the user. 
+
 [2.10.1](https://github.com/bird-house/birdhouse-deploy/tree/2.10.1) (2025-03-10)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/bin/birdhouse
+++ b/bin/birdhouse
@@ -3,6 +3,7 @@
 THIS_FILE="$(readlink -f "$0" || realpath "$0")"
 THIS_DIR="$(dirname "${THIS_FILE}")"
 THIS_BASENAME="$(basename "${THIS_FILE}")"
+COMPOSE_DIR_PREV="${COMPOSE_DIR}"
 COMPOSE_DIR="$(dirname "${THIS_DIR}")/birdhouse"
 
 export BIRDHOUSE_COMPOSE="${BIRDHOUSE_COMPOSE:-"${COMPOSE_DIR}/birdhouse-compose.sh"}"
@@ -79,8 +80,8 @@ READ_CONFIGS_CMD=read_configs
 #   True
 print_config_command() {
   option="$1"
-  configs_cmd_prefix="export __BIRDHOUSE_SUPPORTED_INTERFACE=True ;"
-  configs_cmd_suffix="unset __BIRDHOUSE_SUPPORTED_INTERFACE ;"
+  configs_cmd_prefix="export __BIRDHOUSE_SUPPORTED_INTERFACE=True ; export COMPOSE_DIR=${COMPOSE_DIR} ;"
+  configs_cmd_suffix="unset __BIRDHOUSE_SUPPORTED_INTERFACE ; COMPOSE_DIR='${COMPOSE_DIR_PREV}' ; "
   if [ "${BIRDHOUSE_BACKWARD_COMPATIBLE_ALLOWED+set}" = 'set' ]; then
     configs_cmd_prefix="${configs_cmd_prefix} export BIRDHOUSE_BACKWARD_COMPATIBLE_ALLOWED='${BIRDHOUSE_BACKWARD_COMPATIBLE_ALLOWED}' ;"
   fi


### PR DESCRIPTION
## Overview

The `COMPOSE_DIR` variable cannot be discovered properly if:

- the `bin/birdhouse` script is called from with the `configs --print-config-command` options.
- the result of that call is `eval`ed in order to load the birdhouse configuration settings into the calling process's environment.
- this is done from a directory outside of the birdhouse-deploy source code directory.

This is fixed by explicitly giving a value for the `COMPOSE_DIR` variable when using the `--print-config-command` option. The value is already correctly set in the `bin/birdhouse` script so it is easy to pass that value on to the user. 

## Changes

**Non-breaking changes**
- bug fix

**Breaking changes**
- None

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
