### PR TITLE
Remove deprecated version field from generated docker-compose files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,11 @@
       those docker compose files as well so that you aren't bombarded by deprecation warnings whenever you start
       the birdhouse stack.  
 
+- Remove deprecated version field from generated docker-compose files
+
+  The `env-local` optional component generates a docker compose file that contained a version field which are
+  deprecated. This fixes the issue by removing the code that generates the deprecated field.
+
 [2.10.1](https://github.com/bird-house/birdhouse-deploy/tree/2.10.1) (2025-03-10)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/birdhouse/optional-components/local-dev-test/pre-docker-compose-up.include
+++ b/birdhouse/optional-components/local-dev-test/pre-docker-compose-up.include
@@ -15,7 +15,6 @@ fi
 
 # Note: filename is not docker-compose-extra.yml so that it won't get added prematurely to COMPOSE_CONF_LIST
 THIS_COMPOSE_FILE="${COMPOSE_DIR}/optional-components/local-dev-test/docker-compose-extra-ignore.yml"
-echo 'version: "3.4"' > "${THIS_COMPOSE_FILE}"
 echo "services:" >> "${THIS_COMPOSE_FILE}"
 
 for service in $(PROXY_HTTP_PORT=80 HOSTNAME=${BIRDHOUSE_FQDN} ${DOCKER_COMPOSE} ${COMPOSE_CONF_LIST} config --services 2> /dev/null); do


### PR DESCRIPTION
## Overview

The `env-local` optional component generates a docker compose file that contained a version field which are deprecated. This fixes the issue by removing the code that generates the deprecated field.

## Changes

**Non-breaking changes**
- None

**Breaking changes**
- None

## Related Issue / Discussion

- This should have been included in #504

## Additional Information

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
