### PR TITLE
 Add template expansion to backward compatibility mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,8 @@
       those docker compose files as well so that you aren't bombarded by deprecation warnings whenever you start
       the birdhouse stack.  
 
+- Improve backward-compatibility mode to also template expand old variable names
+
 [2.10.1](https://github.com/bird-house/birdhouse-deploy/tree/2.10.1) (2025-03-10)
 ------------------------------------------------------------------------------------------------------------------
 

--- a/birdhouse/birdhouse-compose.sh
+++ b/birdhouse/birdhouse-compose.sh
@@ -24,6 +24,15 @@ VARS='
   $BIRDHOUSE_LOG_DIR
 '
 
+# For backward-compatibility.
+OLD_VARS='
+  $PAVICS_FQDN
+  $DOC_URL
+  $SUPPORT_EMAIL
+  $DATA_PERSIST_ROOT
+  $DATA_PERSIST_SHARED_ROOT
+'
+
 # list of vars to be substituted in template but they do not have to be set in env.local
 #   their default values are from 'default.env', so they do not have to be defined in 'env.local' if values are adequate
 #   they usually are intended to provide additional features or extended customization of their behavior
@@ -41,6 +50,22 @@ OPTIONAL_VARS='
   $BIRDHOUSE_RELEASE_NOTES_URL
   $BIRDHOUSE_SUPPORT_URL
   $BIRDHOUSE_LICENSE_URL
+'
+
+# For backward-compatibility.
+OLD_OPTIONAL_VARS='
+  $PAVICS_FQDN_PUBLIC
+  $SSL_CERTIFICATE
+  $EXTRA_PYWPS_CONFIG
+  $SERVER_NAME
+  $SERVER_DESCRIPTION
+  $SERVER_INSTITUTION
+  $SERVER_SUBJECT
+  $SERVER_TAGS
+  $SERVER_DOCUMENTATION_URL
+  $SERVER_RELEASE_NOTES_URL
+  $SERVER_SUPPORT_URL
+  $SERVER_LICENSE_URL
 '
 
 THIS_FILE="$(readlink -f "$0" || realpath "$0")"
@@ -94,6 +119,13 @@ if [ x"$1" = x"up" ] || [ x"$1" = x"restart" ] || [ x"${BIRDHOUSE_COMPOSE_TEMPLA
       fi
     fi
     cat "${FILE}" | envsubst "$VARS" | envsubst "$OPTIONAL_VARS" > "${DEST}"
+
+    if [ x"${BIRDHOUSE_BACKWARD_COMPATIBLE_ALLOWED}" = x"True" ]; then
+      cp "${DEST}" "${DEST}.tmp"
+      cat "${DEST}.tmp" | envsubst "$OLD_VARS" | envsubst "$OLD_OPTIONAL_VARS" > "${DEST}"
+      rm "${DEST}.tmp"
+    fi
+
   done
   [ "$?" -eq 1 ] && exit 1  # re-raise the subshell error of the while loop
 else


### PR DESCRIPTION
## Overview

Add template expansion to backward compatibility mode.

Otherwise old external repos using template expansion is broken.

## Changes

**Non-breaking changes**
- Add template expansion to backward compatibility mode.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
