### PR TITLE
Fix setting `BIRDHOUSE_LOCAL_ENV` in `deploy.sh` to the wrong argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@
 
   Also updates a declaration of an external volume in `prometheus-longterm-metrics` to use the compose v2 syntax.
 
+- Fix setting `BIRDHOUSE_LOCAL_ENV` in `deploy.sh` to the wrong argument
+
+  The `deploy.sh` script was setting the `BIRDHOUSE_LOCAL_ENV` variable to the first argument to the script instead
+  of the second one. This is now fixed.
 
 [2.11.0](https://github.com/bird-house/birdhouse-deploy/tree/2.11.0) (2025-03-24)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/deployment/deploy.sh
+++ b/birdhouse/deployment/deploy.sh
@@ -67,7 +67,7 @@ else
     shift
 fi
 
-BIRDHOUSE_LOCAL_ENV="${1:-${BIRDHOUSE_LOCAL_ENV:-"${COMPOSE_DIR}/env.local"}}"
+BIRDHOUSE_LOCAL_ENV="${2:-${BIRDHOUSE_LOCAL_ENV:-"${COMPOSE_DIR}/env.local"}}"
 
 # Setup COMPOSE_DIR and PWD for sourcing env.local.
 # Prevent un-expected difference when this script is run inside autodeploy


### PR DESCRIPTION
## Overview
  
The `deploy.sh` script was setting the `BIRDHOUSE_LOCAL_ENV` variable to the first argument to the script instead of the second one. This is now fixed.


## Changes

**Non-breaking changes**
- Bug fix

**Breaking changes**
- None
 
## Related Issue / Discussion


## Additional Information

Links to other issues or sources.


## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
