### PR TITLE
Jupyter: update to env py311-250423

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,13 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- Jupyter env: new full build with significant changes to the Anaconda environment dependency composition.
+
+  See [Ouranosinc/PAVICS-e2e-workflow-tests#147](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/147)
+  for more info.
+
 
 [2.13.0](https://github.com/bird-house/birdhouse-deploy/tree/2.13.0) (2025-04-04)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/jupyterhub/default.env
+++ b/birdhouse/components/jupyterhub/default.env
@@ -10,7 +10,7 @@ export JUPYTERHUB_IMAGE='${JUPYTERHUB_DOCKER}:${JUPYTERHUB_VERSION}'
 export JUPYTERHUB_IMAGE_URI='registry.hub.docker.com/${JUPYTERHUB_IMAGE}'
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export JUPYTERHUB_DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:py311-241111"
+export JUPYTERHUB_DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:py311-2504023"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond

--- a/birdhouse/components/jupyterhub/default.env
+++ b/birdhouse/components/jupyterhub/default.env
@@ -10,7 +10,7 @@ export JUPYTERHUB_IMAGE='${JUPYTERHUB_DOCKER}:${JUPYTERHUB_VERSION}'
 export JUPYTERHUB_IMAGE_URI='registry.hub.docker.com/${JUPYTERHUB_IMAGE}'
 
 # Jupyter single-user server images, can be overriden in env.local to have a space separated list of multiple images
-export JUPYTERHUB_DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:py311-2504023"
+export JUPYTERHUB_DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:py311-250423"
 
 # Name of the image displayed on the JupyterHub image selection page
 # Can be overriden in env.local to have a space separated list of multiple images, the name order must correspond

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -262,7 +262,7 @@ export GEOSERVER_ADMIN_PASSWORD="${__DEFAULT__GEOSERVER_ADMIN_PASSWORD}"
 #export BIRDHOUSE_ALLOW_UNSECURE_HTTP=""
 
 # Jupyter single-user server images
-#export JUPYTERHUB_DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:py311-241111 \
+#export JUPYTERHUB_DOCKER_NOTEBOOK_IMAGES="pavics/workflow-tests:py311-250423 \
 #                                          pavics/crim-jupyter-eo:0.3.0 \
 #                                          pavics/crim-jupyter-nlp:0.4.0 \
 #                                          birdhouse/pavics-jupyter-base:mlflow-proxy"


### PR DESCRIPTION
## Overview

This PR updates the Jupyter env image with several new versions of dependencies. The Anaconda environment has been overhauled to rely more on native Anaconda packages and to remove many old/incompatible packages.

## Changes

**The version in this PR has not yet been bumped**

_Not adding things here under breaking/non-breaking, as I'm not certain what constitutes either type of change (though I would tend towards these being breaking changes for scientists)_

- Updates the Jupyter environment for PAVICS to py311-250423
  - Anaconda channels now include `nodefaults` and `fortiers` (for `fstd2nc` library).
  - Many obsolete and incompatible plugins and dependencies have been removed, including many `PyPI`-provided packages.
    - The next major release will be built entirely (or almost entirely) from Anaconda packages.

## Related Issue / Discussion

https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/147

## Additional Information

- Matching notebook fixes:
  - Pavics-sdi: https://github.com/Ouranosinc/pavics-sdi/pull/352
  - PAVICS-landing: https://github.com/Ouranosinc/PAVICS-landing/pull/107
  - RavenPy: https://github.com/CSHS-CWRA/RavenPy/pull/484
  - Raven: https://github.com/Ouranosinc/raven/pull/562

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
