### PR TITLE
update Weaver 6.6.0 as the default version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,25 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- Weaver: update `weaver` component default version to [6.6.0](https://github.com/crim-ca/weaver/tree/6.6.0).
+
+  Notable changes include:
+  
+  - Added HTML representation of job status.
+  - Added alternate job `Profile` representations for interoperability with other clients like *WPS* and *openEO*.
+  - Adjust job `status` value for `successful` instead of `succeeded` in accordance to latest OGC API standard edits.
+    If clients were defined with explicit checks of the older value, they can request that job representation using
+    query parameters `?profile=wps&f=json`. Otherwise, it is preferable that scripts are updated to allow either value
+    to ensure the statuses are resolved correctly regardless of Weaver version employed by the server.
+  - Docker build employs [Provenance](https://docs.docker.com/build/metadata/attestations/slsa-provenance)
+    and [Software Bill of Materials (SBOM)](https://docs.docker.com/build/metadata/attestations/sbom) for
+    traceable dependencies, validation of references, and trust for replicable execution pipelines.
+  - Update Python 3.11 to Python 3.12 in the distributed Docker image.
+  - Various bug fixes and security vulnerability fixes.
+
+  For full changelog details, see [Weaver Changes](https://pavics-weaver.readthedocs.io/en/latest/changes.html).
 
 [2.13.4](https://github.com/bird-house/birdhouse-deploy/tree/2.13.4) (2025-05-05)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/weaver/default.env
+++ b/birdhouse/components/weaver/default.env
@@ -55,7 +55,7 @@ OPTIONAL_VARS="
 export WEAVER_CONFIG=HYBRID
 
 # default release version that will be used to fetch docker images (API mananger & celery workers services)
-export WEAVER_VERSION=6.1.1
+export WEAVER_VERSION=6.6.0
 export WEAVER_DOCKER=pavics/weaver
 export WEAVER_IMAGE='${WEAVER_DOCKER}:${WEAVER_VERSION}'
 export WEAVER_MANAGER_IMAGE='${WEAVER_IMAGE}-manager'


### PR DESCRIPTION
## Overview

Update Weaver 6.6.0 as the default version.

## Changes

**Non-breaking changes**
- Weaver: update `weaver` component default version to [6.6.0](https://github.com/crim-ca/weaver/tree/6.6.0).

  Notable changes include:
  
  - Added HTML representation of job status.
  - Added alternate job `Profile` representations for interoperability with other clients like *WPS* and *openEO*.
  - Docker build employs [Provenance](https://docs.docker.com/build/metadata/attestations/slsa-provenance)
    and [Software Bill of Materials (SBOM)](https://docs.docker.com/build/metadata/attestations/sbom) for
    traceable dependencies, validation of references, and trust for replicable execution pipelines.
  - Update Python 3.11 to Python 3.12 in the distributed Docker image.
  - Various bug fixes and security vulnerability fixes.

  For full changelog details, see [Weaver Changes](https://pavics-weaver.readthedocs.io/en/latest/changes.html).

**Breaking changes**
  - Adjust job `status` value for `successful` instead of `succeeded` in accordance to latest OGC API standard edits.
    If clients were defined with explicit checks of the older value, they can request that job representation using
    query parameters `?profile=wps&f=json`. Otherwise, it is preferable that scripts are updated to allow either value
    to ensure the statuses are resolved correctly regardless of Weaver version employed by the server.

## Related Issue / Discussion

- n/a

## CI Operations


birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
