### PR TITLE
Fix issue where the current environment is printed to stdout if no shell exec flags are set.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,12 +15,16 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-## Changes
+## Fixes
 
-- Fix bugs in Prometheus log parser meant to measure download volume. 
+- Fix bugs in Prometheus log parser meant to measure download volume.
+
+- Fix issue where the current environment is printed to stdout if no shell exec flags are set.
 
 [2.15.1](https://github.com/bird-house/birdhouse-deploy/tree/2.15.1) (2025-06-04)
 ------------------------------------------------------------------------------------------------------------------
+
+## Changes
 
 - Stop build when a build step fails
 

--- a/birdhouse/scripts/error-handling.include.sh
+++ b/birdhouse/scripts/error-handling.include.sh
@@ -6,7 +6,7 @@ if [ "$_BIRDHOUSE_ERROR_HANDLING_ENABLED" != "true" ]; then
     [ "$BIRDHOUSE_DEBUG_MODE" = "$true" ] && SHELL_EXEC_FLAGS="$SHELL_EXEC_FLAGS -x"
     [ "$BIRDHOUSE_FAIL_FAST" = "$true" ] && SHELL_EXEC_FLAGS="$SHELL_EXEC_FLAGS -e"
 
-    set ${SHELL_EXEC_FLAGS}
+    [ -n "$SHELL_EXEC_FLAGS" ] && set ${SHELL_EXEC_FLAGS}
 
     exit_handler() {
         exit_code="$?"


### PR DESCRIPTION
## Overview

If `set` is called without any arguments it prints the current environment to stdout (on most distros). We don't want this, so we only call `set` if there are arguments.

Also makes formatting updates to CHANGES.md

## Changes

**Non-breaking changes**
- Bug fix
**Breaking changes**
- none
- 
## Related Issue / Discussion


## Additional Information

Links to other issues or sources.


## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
