### PR TITLE
Add proxy access log backup

### DIFF
--- a/birdhouse/components/proxy/backup
+++ b/birdhouse/components/proxy/backup
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+backup_logs() {
+  _do_backup() {
+    ${BIRDHOUSE_EXE} --quiet compose run --rm \
+                             -v ${BIRDHOUSE_BACKUP_VOLUME}:/backup \
+                             proxy \
+                             sh -c "mkdir /backup/proxy-logs; cp ${PROXY_LOG_PATH} /backup/proxy-logs/${PROXY_LOG_FILE}"
+  }
+  backup_create_runner 'proxy access logs' _do_backup 'proxy'
+}
+
+restore_logs() {
+  BIRDHOUSE_BACKUP_RESTORE_NO_CLOBBER=true backup_restore_runner 'proxy access logs' : 'proxy-logs'
+}


### PR DESCRIPTION
## Overview

Add proxy access log backup.

This should have been added in #532. I'm adding it separately because #532 is so close to being pulled in that I wanted any additional discussion to happen elsewhere.

## Changes

**Breaking changes**

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
