### PR TITLE
Fix 'thredds_transfer_size_kb_total' name in prometheus-long-term-rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,10 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+- Fix 'thredds_transfer_size_kb_total' name in prometheus-long-term-rules
+
+  Counter names have the suffix `_total`. Without this suffix, the counter value is not discovered
+  properly in a rule and the prometheus rule will never return valid data.
 
 [2.16.1](https://github.com/bird-house/birdhouse-deploy/tree/2.16.1) (2025-06-17)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/optional-components/prometheus-longterm-rules/config/monitoring/prometheus.rules
+++ b/birdhouse/optional-components/prometheus-longterm-rules/config/monitoring/prometheus.rules
@@ -38,7 +38,7 @@ groups:
 
         # Total download volume in the last 1 hour logged by the prometheus-log-exporter counter
         - record: thredds:kb_transfer_size_kb:increase_1h
-          expr: increase(thredds_transfer_size_kb[1h])
+          expr: increase(thredds_transfer_size_kb_total[1h])
           labels:
             group: longterm-metrics
 
@@ -127,4 +127,3 @@ groups:
           expr: round(sum by(name) (rate(container_last_seen{name=~"jupyter-.+"}[1d]) > 0.9))
           labels:
             group: longterm-metrics
-


### PR DESCRIPTION
## Overview

Counter names have the suffix `_total`. Without this suffix, the counter value is not discovered properly in a rule and the prometheus rule will never return valid data.

## Changes

**Non-breaking changes**
- bugfix

**Breaking changes**
- None

## Related Issue / Discussion

## Additional Information

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
