### PR TITLE
fix empty newlines displayed on `COMPOSE_CONF_LIST`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,9 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes 
+
+- Fix empty newlines displayed on `COMPOSE_CONF_LIST` output.
 
 [2.16.4](https://github.com/bird-house/birdhouse-deploy/tree/2.16.4) (2025-07-03)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/birdhouse-compose.sh
+++ b/birdhouse/birdhouse-compose.sh
@@ -116,7 +116,7 @@ fi
 create_compose_conf_list # this sets COMPOSE_CONF_LIST
 log INFO "Displaying resolved compose configurations:"
 log INFO "COMPOSE_CONF_LIST="
-log INFO "$(echo "${COMPOSE_CONF_LIST}" | tr ' ' '\n' | grep -v '^-f')"
+log INFO "$(echo "${COMPOSE_CONF_LIST}" | tr ' ' '\n' | grep -v '^-f' | grep -v '^$')"
 
 if [ x"$1" = x"info" ]; then
   log INFO "Stopping before execution of docker-compose command."


### PR DESCRIPTION
## Overview

Before, depending on how the `COMPOSE_CONF_LIST` was aggregated / formed by sourcing everything, the output could look like the following: 


```
INFO:     COMPOSE_CONF_LIST=
INFO:     docker-compose.yml
          ./components/proxy/docker-compose-extra.yml
          
          ./components/magpie/docker-compose-extra.yml
          
          ./components/magpie/config/proxy/docker-compose-extra.yml
          ./components/twitcher/docker-compose-extra.yml
          
          ./components/twitcher/config/proxy/docker-compose-extra.yml
          ./components/wps_outputs-volume/docker-compose-extra.yml
          
          ./components/wps_outputs-volume/config/proxy/docker-compose-extra.yml
          ./components/cowbird/docker-compose-extra.yml
          
          ./components/cowbird/config/magpie/docker-compose-extra.yml
          ./components/cowbird/config/proxy/docker-compose-extra.yml
          ./components/stac/docker-compose-extra.yml
          
          ./components/stac/config/magpie/docker-compose-extra.yml
          ./components/stac/config/proxy/docker-compose-extra.yml
          ./components/stac/config/twitcher/docker-compose-extra.yml
          
          ./components/magpie/config/canarie-api/docker-compose-extra.yml
          
          ./components/twitcher/config/canarie-api/docker-compose-extra.yml
          
          ./components/wps_outputs-volume/config/canarie-api/docker-compose-extra.yml
          
          ./components/cowbird/config/canarie-api/docker-compose-extra.yml
          
          ./components/stac/config/canarie-api/docker-compose-extra.yml
          
          
          
          ./components/cowbird/config/geoserver/docker-compose-extra.yml
          
          
          
          ./components/cowbird/config/jupyterhub/docker-compose-extra.yml
          
          
          
          ./components/canarie-api/docker-compose-extra.yml
          
          ./components/magpie/config/canarie-api/docker-compose-extra.yml
          
          ./components/twitcher/config/canarie-api/docker-compose-extra.yml
          
          ./components/wps_outputs-volume/config/canarie-api/docker-compose-extra.yml
          
          ./components/cowbird/config/canarie-api/docker-compose-extra.yml
          
          ./components/stac/config/canarie-api/docker-compose-extra.yml
          
          ./components/canarie-api/config/proxy/docker-compose-extra.yml
          ./components/postgres/docker-compose-extra.yml
          
          ./components/finch/docker-compose-extra.yml
          
          ./components/finch/config/canarie-api/docker-compose-extra.yml
          ./components/finch/config/magpie/docker-compose-extra.yml
          ./components/finch/config/wps_outputs-volume/docker-compose-extra.yml
          ./components/geoserver/docker-compose-extra.yml
          
          ./components/cowbird/config/geoserver/docker-compose-extra.yml
          
          ./components/geoserver/config/canarie-api/docker-compose-extra.yml
          ./components/geoserver/config/magpie/docker-compose-extra.yml
          ./components/geoserver/config/proxy/docker-compose-extra.yml
          ./components/data-volume/docker-compose-extra.yml
          
          ./components/hummingbird/docker-compose-extra.yml
          
          ./components/hummingbird/config/canarie-api/docker-compose-extra.yml
          ./components/hummingbird/config/data-volume/docker-compose-extra.yml
          ./components/hummingbird/config/magpie/docker-compose-extra.yml
          ./components/hummingbird/config/wps_outputs-volume/docker-compose-extra.yml
          ./components/jupyterhub/docker-compose-extra.yml
          
          ./components/cowbird/config/jupyterhub/docker-compose-extra.yml
          
          ./components/jupyterhub/config/canarie-api/docker-compose-extra.yml
          ./components/jupyterhub/config/magpie/docker-compose-extra.yml
          ./components/jupyterhub/config/proxy/docker-compose-extra.yml
          ./components/raven/docker-compose-extra.yml
          
          ./components/raven/config/canarie-api/docker-compose-extra.yml
          ./components/raven/config/magpie/docker-compose-extra.yml
          ./components/raven/config/wps_outputs-volume/docker-compose-extra.yml
          ./components/thredds/docker-compose-extra.yml
          
          ./components/thredds/config/canarie-api/docker-compose-extra.yml
          ./components/thredds/config/magpie/docker-compose-extra.yml
          ./components/thredds/config/proxy/docker-compose-extra.yml
          
          ./optional-components/canarie-api-full-monitoring/config/canarie-api/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/cowbird/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/finch/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/hummingbird/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/raven/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/thredds/docker-compose-extra.yml
          
          
          ./optional-components/secure-thredds/config/magpie/docker-compose-extra.yml
          ./components/weaver/docker-compose-extra.yml
          
          ./optional-components/canarie-api-full-monitoring/config/weaver/docker-compose-extra.yml
          
          ./components/weaver/config/canarie-api/docker-compose-extra.yml
          ./components/weaver/config/magpie/docker-compose-extra.yml
          ./components/weaver/config/proxy/docker-compose-extra.yml
          ./components/weaver/config/twitcher/docker-compose-extra.yml
          ./optional-components/test-weaver/docker-compose-extra.yml
          
          
          ./optional-components/secure-data-proxy/config/magpie/docker-compose-extra.yml
          ./optional-components/secure-data-proxy/config/proxy/docker-compose-extra.yml
          
          ./optional-components/x-robots-tag-header/config/proxy/docker-compose-extra.yml
          
          ./optional-components/stac-public-access/config/magpie/docker-compose-extra.yml
          
          ./optional-components/stac-public-access/config/stac-data-proxy/docker-compose-extra.yml
          
          ./optional-components/stac-data-proxy/config/proxy/docker-compose-extra.yml
          ./optional-components/stac-data-proxy/config/secure-data-proxy/docker-compose-extra.yml
          ../../daccs-env/docker-compose-extra.yml
          
          ../../daccs-env/config/cowbird/docker-compose-extra.yml
          ../../daccs-env/config/finch/docker-compose-extra.yml
          ../../daccs-env/config/hummingbird/docker-compose-extra.yml
          ../../daccs-env/config/jupyterhub/docker-compose-extra.yml
          ../../daccs-env/config/raven/docker-compose-extra.yml
          ../../daccs-env/config/stac/docker-compose-extra.yml
          ../../daccs-env/config/twitcher/docker-compose-extra.yml
          ../../daccs-env/config/weaver/docker-compose-extra.yml
          
          ./optional-components/backwards-compatible-overrides/config/jupyterhub/docker-compose-extra.yml
INFO:     Executing docker-compose with extra options: stop
```

Following this change, superfluous newlines are removed. 


```
INFO:     Displaying resolved compose configurations:
INFO:     COMPOSE_CONF_LIST=
INFO:     docker-compose.yml
          ./components/proxy/docker-compose-extra.yml
          ./components/magpie/docker-compose-extra.yml
          ./components/magpie/config/proxy/docker-compose-extra.yml
          ./components/twitcher/docker-compose-extra.yml
          ./components/twitcher/config/proxy/docker-compose-extra.yml
          ./components/wps_outputs-volume/docker-compose-extra.yml
          ./components/wps_outputs-volume/config/proxy/docker-compose-extra.yml
          ./components/cowbird/docker-compose-extra.yml
          ./components/cowbird/config/magpie/docker-compose-extra.yml
          ./components/cowbird/config/proxy/docker-compose-extra.yml
          ./components/stac/docker-compose-extra.yml
          ./components/stac/config/magpie/docker-compose-extra.yml
          ./components/stac/config/proxy/docker-compose-extra.yml
          ./components/stac/config/twitcher/docker-compose-extra.yml
          ./components/magpie/config/canarie-api/docker-compose-extra.yml
          ./components/twitcher/config/canarie-api/docker-compose-extra.yml
          ./components/wps_outputs-volume/config/canarie-api/docker-compose-extra.yml
          ./components/cowbird/config/canarie-api/docker-compose-extra.yml
          ./components/stac/config/canarie-api/docker-compose-extra.yml
          ./components/cowbird/config/geoserver/docker-compose-extra.yml
          ./components/cowbird/config/jupyterhub/docker-compose-extra.yml
          ./components/canarie-api/docker-compose-extra.yml
          ./components/magpie/config/canarie-api/docker-compose-extra.yml
          ./components/twitcher/config/canarie-api/docker-compose-extra.yml
          ./components/wps_outputs-volume/config/canarie-api/docker-compose-extra.yml
          ./components/cowbird/config/canarie-api/docker-compose-extra.yml
          ./components/stac/config/canarie-api/docker-compose-extra.yml
          ./components/canarie-api/config/proxy/docker-compose-extra.yml
          ./components/postgres/docker-compose-extra.yml
          ./components/finch/docker-compose-extra.yml
          ./components/finch/config/canarie-api/docker-compose-extra.yml
          ./components/finch/config/magpie/docker-compose-extra.yml
          ./components/finch/config/wps_outputs-volume/docker-compose-extra.yml
          ./components/geoserver/docker-compose-extra.yml
          ./components/cowbird/config/geoserver/docker-compose-extra.yml
          ./components/geoserver/config/canarie-api/docker-compose-extra.yml
          ./components/geoserver/config/magpie/docker-compose-extra.yml
          ./components/geoserver/config/proxy/docker-compose-extra.yml
          ./components/data-volume/docker-compose-extra.yml
          ./components/hummingbird/docker-compose-extra.yml
          ./components/hummingbird/config/canarie-api/docker-compose-extra.yml
          ./components/hummingbird/config/data-volume/docker-compose-extra.yml
          ./components/hummingbird/config/magpie/docker-compose-extra.yml
          ./components/hummingbird/config/wps_outputs-volume/docker-compose-extra.yml
          ./components/jupyterhub/docker-compose-extra.yml
          ./components/cowbird/config/jupyterhub/docker-compose-extra.yml
          ./components/jupyterhub/config/canarie-api/docker-compose-extra.yml
          ./components/jupyterhub/config/magpie/docker-compose-extra.yml
          ./components/jupyterhub/config/proxy/docker-compose-extra.yml
          ./components/raven/docker-compose-extra.yml
          ./components/raven/config/canarie-api/docker-compose-extra.yml
          ./components/raven/config/magpie/docker-compose-extra.yml
          ./components/raven/config/wps_outputs-volume/docker-compose-extra.yml
          ./components/thredds/docker-compose-extra.yml
          ./components/thredds/config/canarie-api/docker-compose-extra.yml
          ./components/thredds/config/magpie/docker-compose-extra.yml
          ./components/thredds/config/proxy/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/canarie-api/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/cowbird/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/finch/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/hummingbird/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/raven/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/thredds/docker-compose-extra.yml
          ./optional-components/secure-thredds/config/magpie/docker-compose-extra.yml
          ./components/weaver/docker-compose-extra.yml
          ./optional-components/canarie-api-full-monitoring/config/weaver/docker-compose-extra.yml
          ./components/weaver/config/canarie-api/docker-compose-extra.yml
          ./components/weaver/config/magpie/docker-compose-extra.yml
          ./components/weaver/config/proxy/docker-compose-extra.yml
          ./components/weaver/config/twitcher/docker-compose-extra.yml
          ./optional-components/test-weaver/docker-compose-extra.yml
          ./optional-components/secure-data-proxy/config/magpie/docker-compose-extra.yml
          ./optional-components/secure-data-proxy/config/proxy/docker-compose-extra.yml
          ./optional-components/x-robots-tag-header/config/proxy/docker-compose-extra.yml
          ./optional-components/stac-public-access/config/magpie/docker-compose-extra.yml
          ./optional-components/stac-public-access/config/stac-data-proxy/docker-compose-extra.yml
          ./optional-components/stac-data-proxy/config/proxy/docker-compose-extra.yml
          ./optional-components/stac-data-proxy/config/secure-data-proxy/docker-compose-extra.yml
          ../../daccs-env/docker-compose-extra.yml
          ../../daccs-env/config/cowbird/docker-compose-extra.yml
          ../../daccs-env/config/finch/docker-compose-extra.yml
          ../../daccs-env/config/hummingbird/docker-compose-extra.yml
          ../../daccs-env/config/jupyterhub/docker-compose-extra.yml
          ../../daccs-env/config/raven/docker-compose-extra.yml
          ../../daccs-env/config/stac/docker-compose-extra.yml
          ../../daccs-env/config/twitcher/docker-compose-extra.yml
          ../../daccs-env/config/weaver/docker-compose-extra.yml
          ./optional-components/backwards-compatible-overrides/config/jupyterhub/docker-compose-extra.yml
INFO:     Executing docker-compose with extra options: stop 
```



## Changes

**Non-breaking changes**
- fix empty newlines displayed on `COMPOSE_CONF_LIST`
This is no-impact to the actual content, just pretty-printing. 

**Breaking changes**
- n/a

## CI Operations

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
