### PR TITLE
Patch fix rsync command

### DIFF
--- a/birdhouse/deployment/deploy-data-raven-testdata-to-thredds.yml
+++ b/birdhouse/deployment/deploy-data-raven-testdata-to-thredds.yml
@@ -8,4 +8,4 @@ deploy:
   - source_dir: ./data
     dest_dir: /data/datasets/testdata/raven
     # sync all files used for tests
-    rsync_extra_opts: --include=*/ --*.geojson --include=*.rv* --include=*.nc --include=*.tiff --include=*.txt --include=*.zip --exclude=*
+    rsync_extra_opts: --include=*/ --include=*.geojson --include=*.nc --include=*.rv* --include=*.tiff --include=*.txt --include=*.zip --exclude=*


### PR DESCRIPTION
## Overview

This is a patch fix for a malformed `rsync` command introduced in #564 

## Changes

**Non-breaking changes**
- Fixes a malformed `rsync` command

## Related Issue / Discussion

- Resolves [issue id](url)

## Additional Information

Links to other issues or sources.

- [ ] Things to do...

## CI Operations

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
