### PR TITLE
Thanos-minio container should always restart on failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,12 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Thanos-minio container should always restart on failure
+
+  Since this container wasn't restarting automatically it could make the entire stack unavailable if it failed.
+  The proxy container would refuse to start since it could not connect to the upstream thanos-minio server.
 
 [2.16.7](https://github.com/bird-house/birdhouse-deploy/tree/2.16.7) (2025-08-05)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/optional-components/thanos/docker-compose-extra.yml
+++ b/birdhouse/optional-components/thanos/docker-compose-extra.yml
@@ -70,6 +70,7 @@ services:
       - ${THANOS_MINIO_DATA_STORE}:/data
       - ./optional-components/thanos/minio-entrypoint:/entrypoint
     entrypoint: /entrypoint
+    restart: always
     command:
       - 'minio'
       - 'server'


### PR DESCRIPTION
## Overview

Since this container wasn't restarting automatically it could make the entire stack unavailable if it failed.
The proxy container would refuse to start since it could not connect to the upstream thanos-minio server.

## Changes

**Non-breaking changes**
- bugfix

**Breaking changes**
- None

## Related Issue / Discussion

## Additional Information

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
