### PR TITLE
Allow user generated jupyterlab kernels to persist between sessions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,32 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Allow user generated jupyterlab kernels to persist between sessions
+
+  If a jupyterlab user wants to create a virtual environment to use as a kernel they can do so
+  by creating a new virtual environment and installing it as a kernel with the `python -m ipykernel install`
+  command.
+
+  By default this command installs the kernel metadata in `/usr/local/share/jupyter/kernels` which is not
+  persisted to a docker volume and so the kernel is no longer visible when the jupyterlab container restarts.
+  Alternatively, the command can be run with the `--user` flag which installs the kernel metadata to the user's
+  home directory (which is persisted to a docker volume) but the jupyterlab API does not recognize kernels
+  installed in this way for some reason.
+
+  To solve this issue, this creates a symlink from the kernels metadata folder in the user's home directory to
+  a location outside of the user's home directory (`/usr/local/share/jupyter/user-kernels/kernels`) which can
+  be detected by the juptyerlab API.
+
+- Ensure jupyterlab container healthchecks don't fail by default
+
+  The healthchecks assume that the jupyter data directory is in `/home/$NB_USER/.local` regardless of the value 
+  of $HOME. This means that healthechecks for the jupyterlab containers were always failing even if the
+  container was actually healthy.
+
+  This fixes the issue by symlinking the relevant folder to `/home/$NB_USER/.local` within the container so that 
+  the healthchecks can run as expected.
 
 [2.16.7](https://github.com/bird-house/birdhouse-deploy/tree/2.16.7) (2025-08-05)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/components/jupyterhub/jupyterhub_config.py.template
@@ -98,10 +98,16 @@ notebook_dir = '/notebook_dir'
 jupyterhub_data_dir = os.environ['JUPYTERHUB_USER_DATA_DIR']
 container_workspace_dir = join(notebook_dir, "writable-workspace")
 container_home_dir = join(container_workspace_dir, ".home")
+user_kernels_dir = "/usr/local/share/jupyter/user-kernels"
 
 c.DockerSpawner.notebook_dir = notebook_dir
 c.DockerSpawner.environment = {
     "HOME": container_home_dir,
+    # Adds a custom path that jupyterlab will use to search for kernels so that
+    # user-generated kernels can be detected by jupyterlab (the default location
+    # in the home directory is not visible to jupyterlab for some reason).
+    # See c.DockerSpawner.post_start_cmd for more info.
+    "JUPYTER_PATH": user_kernels_dir,
     # https://docs.bokeh.org/en/latest/docs/user_guide/jupyter.html#jupyterhub
     # Issue https://github.com/bokeh/bokeh/issues/12090
     # Post on Panel forum:
@@ -261,6 +267,19 @@ if jupyter_idle_server_cull_timeout or jupyter_idle_kernel_cull_timeout:
         '--MappingKernelManager.cull_connected=True',
         '--TerminalManager.cull_connected=True',
     ])
+
+# This ensures that the docker healthchecks pass for the jupyterlab containers
+# The healthchecks assume that the jupyter data directory is in /home/$NB_USER/.local
+# regardless of the value of $HOME.
+# It also makes a symlink between the kernels directory in the user space to another
+# location outside of the home directory. This is because jupyterlab is currently unable
+# to detect kernels inside the user's home directory for some reason.
+_post_start_command = (
+    "ln -s $HOME/.local /home/$NB_USER/.local; "
+    f"mkdir -p {user_kernels_dir}; "
+    f"ln -s $HOME/.local/share/jupyter/kernels {user_kernels_dir}/kernels"
+)
+c.DockerSpawner.post_start_cmd = f"sh -c '{_post_start_command}'"
 
 # ------------------------------------------------------------------------------
 # Configuration overrides


### PR DESCRIPTION
## Overview

If a jupyterlab user wants to create a virtual environment to use as a kernel they can do so by creating a new virtual environment and installing it as a kernel with the `python -m ipykernel install` command.

By default this command installs the kernel metadata in `/usr/local/share/jupyter/kernels` which is not persisted to a docker volume and so the kernel is no longer visible when the jupyterlab container restarts.
Alternatively, the command can be run with the `--user` flag which installs the kernel metadata to the user's home directory (which is persisted to a docker volume) but the jupyterlab API does not recognize kernels installed in this way for some reason.

To solve this issue, this creates a symlink from the kernels metadata folder in the user's home directory to a location outside of the user's home directory (`/usr/local/share/jupyter/user-kernels/kernels`) which can be detected by the juptyerlab API.

Also fixes:

The jupyterlab container healthchecks assume that the jupyter data directory is in `/home/$NB_USER/.local` regardless of the value of $HOME. This means that healthechecks for the jupyterlab containers were always failing even if the container was actually healthy.

This fixes the issue by symlinking the relevant folder to `/home/$NB_USER/.local` within the container so that the healthchecks can run as expected.

## Changes

**Non-breaking changes**
- bug fixes

**Breaking changes**

## Related Issue / Discussion


## Additional Information

Links to other issues or sources.

- [ ] Things to do...

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
