### PR TITLE
Update all STAC components + extra functionalities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,20 @@
 
 ## Changes
 
+- STAC: Update STAC Browser to
+  [`crim-ca/stac-browser:3.4.0-dev`](https://github.com/crim-ca/stac-browser/releases/tag/3.4.0-dev).
+
+  - Dockers are now built directly with the GitHub CI releases
+    (see https://github.com/crim-ca/stac-browser/pkgs/container/stac-browser).
+  - Synchronize with latest changes (as of 2025-08-16).
+    - Beside the necessary `prefixPath` override for Nginx Proxy redirect and a minor HTML file resolution fix,
+      the image is entirely up-to-date with the official upstream code.
+    - Supports STAC 1.1.0.
+    - Supports language locales.
+    - Greatly improves parsing of STAC metadata and their visual rendering.
+    - Allows dynamic runtime [config.js](https://github.com/radiantearth/stac-browser/blob/main/config.js) overrides.
+      For the time being, only the required `catalogUrl` is overridden, but further settings could be added later on.
+
 - STAC: Update STAC API to `crim-ca/stac-app:2.0.1`.
 
   - Changes in [`crim-ca/stac-app:2.0.0`](https://github.com/crim-ca/stac-app/releases/tag/2.0.0) includes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,21 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- STAC: Update STAC API to `crim-ca/stac-app:2.0.1`.
+
+  - Changes in [`crim-ca/stac-app:2.0.0`](https://github.com/crim-ca/stac-app/releases/tag/2.0.0) includes:
+    - migration to `stac-fastapi==6.0.0` and corresponding fixes to support it
+    - add `q` parameter free-text search on `/search`, `/collections` and `/collections/{collectionId}/items` endpoints
+    - enforce JSON schema validation of all `stac_extensions` referenced by published STAC Items and Collections
+    - multiple dependency updates
+  - Minor package dependency fix in [`crim-ca/stac-app:2.0.1`](https://github.com/crim-ca/stac-app/releases/tag/2.0.1).
+
+- STAC: Update `stac-db` and `stac-migration` to version `0.9.8`.
+
+- STAC: Add `optional/stac-db-persist` and `STAC_DB_PERSIST_DIR` to allow custom STAC DB metadata storage location.
+
 
 [2.16.9](https://github.com/bird-house/birdhouse-deploy/tree/2.16.9) (2025-08-15)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/stac/default.env
+++ b/birdhouse/components/stac/default.env
@@ -30,16 +30,17 @@ export STAC_DB_IMAGE='${STAC_DB_DOCKER}:${STAC_DB_TAGGED}'
 # Note however that migration between different minor pgstac versions might not be automatically supported.
 # This is because pgstac minor versions introduce PostGreSQL major versions updates, which requires manual intervention.
 # In case major updates pose too much problems, consider using 'stac-populator' image with 'birdhouse backup' feature.
-export STAC_MIGRATION_VERSION=0.9.6
+export STAC_MIGRATION_VERSION=0.9.8
 export STAC_MIGRATION_TAGGED='v${STAC_MIGRATION_VERSION}'
 export STAC_MIGRATION_DOCKER='${STAC_DB_DOCKER}-pypgstac'
 export STAC_MIGRATION_IMAGE='${STAC_MIGRATION_DOCKER}:${STAC_MIGRATION_TAGGED}'
 
-# 'docker_image_push' branch points at https://github.com/crim-ca/stac-browser/tree/docker_image_push
-# which is some commits ahead of 'v3.0.0-beta.5' (and multiple behind latest official releases)
-# version name is slightly tweaked to fulfill schema while leaving an obvious trace
-export STAC_BROWSER_VERSION=3.0.0-beta.5-crim-docker-image-push
-export STAC_BROWSER_IMAGE='ghcr.io/crim-ca/stac-browser:docker_image_push'
+# CRIM image (https://github.com/crim-ca/stac-browser)
+# is a fork of the official stac-browser (https://github.com/radiantearth/stac-browser)
+# which is some commits ahead to provide necessary build argument fixes for redirects by the nginx proxy.
+# version name is slightly tweaked to fulfill 'service-config' JSON schema while leaving an obvious trace of the source
+export STAC_BROWSER_VERSION=3.4.0-dev-crim
+export STAC_BROWSER_IMAGE='ghcr.io/crim-ca/stac-browser:3.4.0-dev'
 export STAC_BROWSER_IMAGE_URI='${STAC_BROWSER_IMAGE}'
 
 # for use with 'birdhouse backup create -r stac --no-restic' command

--- a/birdhouse/components/stac/default.env
+++ b/birdhouse/components/stac/default.env
@@ -1,3 +1,12 @@
+# NOTE:
+#   See also the following optional components that can be used in conjunction with this component to further
+#   customize the data management, persistence and access mechanisms of the STAC API.
+#
+#   - birdhouse/optional-components/stac-data-proxy
+#   - birdhouse/optional-components/stac-db-persist
+#   - birdhouse/optional-components/stac-populator
+#   - birdhouse/optional-components/stac-public-access
+
 export STAC_POSTGRES_USER='${BIRDHOUSE_POSTGRES_USERNAME}'
 export STAC_POSTGRES_PASSWORD='${BIRDHOUSE_POSTGRES_PASSWORD}'
 export STAC_PGUSER='${BIRDHOUSE_POSTGRES_USERNAME}'
@@ -7,12 +16,13 @@ export STAC_PGPASSWORD='${BIRDHOUSE_POSTGRES_PASSWORD}'
 #   crim-ca/stac-app:0.0.0 uses STAC-fastapi version 2.4.3 with pgstac 0.6.10 (technically <0.7)
 #   crim-ca/stac-app:1.0.0 uses STAC-fastapi version 3.0.3 with pgstac 0.6.10 (techically >=0.7,<0.8, but 0.6 works)
 #   crim-ca/stac-app:1.1.0 uses STAC-fastapi version 5.2.0 with pgstac 0.9.6 (techically >=0.8,<0.10)
-export STAC_VERSION=5.2.0-crim-1.1.0
-export STAC_IMAGE='ghcr.io/crim-ca/stac-app:1.1.0'
+#   crim-ca/stac-app:2.0.1 uses STAC-fastapi version 6.0.0 with pgstac 0.9.6+ (techically >=0.8,<0.10)
+export STAC_VERSION=6.0.0-crim-2.0.1
+export STAC_IMAGE='ghcr.io/crim-ca/stac-app:2.0.1'
 export STAC_IMAGE_URI='${STAC_IMAGE}'
 # database SQL schemas must be aligned with STAC_VERSION
 # there versions are not "equal", check compatibilities on https://github.com/stac-utils/stac-fastapi-pgstac
-export STAC_DB_VERSION=0.9.6
+export STAC_DB_VERSION=0.9.8
 export STAC_DB_TAGGED='v${STAC_DB_VERSION}'
 export STAC_DB_DOCKER='ghcr.io/stac-utils/pgstac'
 export STAC_DB_IMAGE='${STAC_DB_DOCKER}:${STAC_DB_TAGGED}'

--- a/birdhouse/components/stac/docker-compose-extra.yml
+++ b/birdhouse/components/stac/docker-compose-extra.yml
@@ -37,8 +37,14 @@ services:
     container_name: stac-browser
     image: ${STAC_BROWSER_IMAGE}
     environment:
+      # backward compat for older image versions (ghcr.io/crim-ca/stac-browser:docker_image_push)
       - CATALOG_URL=${BIRDHOUSE_PROXY_SCHEME}://${BIRDHOUSE_FQDN_PUBLIC}/stac/
       - ROOT_PATH=/stac-browser/
+      # newer image versions (ghcr.io/radiantearth/stac-browser, mininum version 3.1.1)
+      # anything in the config (except build params) can be overridden by environment variables with 'SB_' prefix
+      # (https://github.com/radiantearth/stac-browser/blob/main/config.js)
+      # (https://github.com/radiantearth/stac-browser/blob/main/docs/docker.md)
+      - SB_catalogUrl=${BIRDHOUSE_PROXY_SCHEME}://${BIRDHOUSE_FQDN_PUBLIC}/stac/
     logging: *default-logging
     restart: always
     healthcheck:

--- a/birdhouse/optional-components/stac-db-persist/config/stac/docker-compose-extra.yml
+++ b/birdhouse/optional-components/stac-db-persist/config/stac/docker-compose-extra.yml
@@ -1,0 +1,7 @@
+volumes:
+  stac-db:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${STAC_DB_PERSIST_DIR}
+      o: bind

--- a/birdhouse/optional-components/stac-db-persist/default.env
+++ b/birdhouse/optional-components/stac-db-persist/default.env
@@ -1,0 +1,13 @@
+# Allows specifying a custom directory location of data of 'stac-db' service supplying the STAC API.
+# When this component is not enabled, the default is a 'stac-db' volume auto-created by docker-compose.
+# If mounting using another strategy than the provided local path bind mount, use a custom docker-compose YAML override.
+export STAC_DB_PERSIST_DIR='${BIRDHOUSE_DATA_PERSIST_ROOT}/stac-db_persist'
+
+export DELAYED_EVAL="
+  $DELAYED_EVAL
+  STAC_DB_PERSIST_DIR
+"
+
+COMPONENT_DEPENDENCIES="
+  ./components/stac
+"


### PR DESCRIPTION
## Overview

Update all STAC components and extra functionalities related to them.

## Changes

**Non-breaking changes**

>[!WARNING]
> Assumes that STAC API `5.2.0-crim-1.1.0` (default) is already applied. If migrating from older versions, all database migration issues when moving from 3.x still apply. 

- STAC: Update STAC Browser to
  [`crim-ca/stac-browser:3.4.0-dev`](https://github.com/crim-ca/stac-browser/releases/tag/3.4.0-dev).

  - Dockers are now built directly with the GitHub CI releases
    (see https://github.com/crim-ca/stac-browser/pkgs/container/stac-browser).
  - Synchronize with latest changes (as of 2025-08-16).
    - Beside the necessary `prefixPath` override for Nginx Proxy redirect and a minor HTML file resolution fix,
      the image is entirely up-to-date with the official upstream code.
    - Supports STAC 1.1.0.
    - Supports language locales.
    - Greatly improves parsing of STAC metadata and their visual rendering.
    - Allows dynamic runtime [config.js](https://github.com/radiantearth/stac-browser/blob/main/config.js) overrides.
      For the time being, only the required `catalogUrl` is overridden, but further settings could be added later on.

- STAC: Update STAC API to `crim-ca/stac-app:2.0.1`.

  - Changes in [`crim-ca/stac-app:2.0.0`](https://github.com/crim-ca/stac-app/releases/tag/2.0.0) includes:
    - migration to `stac-fastapi==6.0.0` and corresponding fixes to support it
    - add `q` parameter free-text search on `/search`, `/collections` and `/collections/{collectionId}/items` endpoints
    - enforce JSON schema validation of all `stac_extensions` referenced by published STAC Items and Collections
    - multiple dependency updates
  - Minor package dependency fix in [`crim-ca/stac-app:2.0.1`](https://github.com/crim-ca/stac-app/releases/tag/2.0.1).

- STAC: Update `stac-db` and `stac-migration` to version `0.9.8`.

- STAC: Add `optional/stac-db-persist` and `STAC_DB_PERSIST_DIR` to allow custom STAC DB metadata storage location.

**Breaking changes**
- n/a

## Related Issue / Discussion

- #561 
- https://github.com/crim-ca/stac-app/pull/37
- https://github.com/crim-ca/stac-app/pull/28
- https://github.com/crim-ca/stac-app/pull/40
- https://github.com/crim-ca/stac-browser/pull/6



## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
