### PR TITLE
Revert CI labeler action

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -20,6 +20,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+    - uses: actions/labeler@v2  # forced version - v5 does not have the same config file structure!
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Overview

The V5 version set in https://github.com/bird-house/birdhouse-deploy/pull/574 does not align with the provided configuration.

See for example on an active PR: 
https://github.com/bird-house/birdhouse-deploy/actions/runs/17250273776/job/48950581278?pr=576
<img width="810" height="314" alt="{DA04A23E-1E16-42E1-8860-BF68C3682F34}" src="https://github.com/user-attachments/assets/dad697b7-a131-4135-9e7e-74c3c0a5c2b6" />


## CI Operations

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
