### PR TITLE
Drop unsupported `pytest-lazy-fixture` python package for tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,13 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- Drop unsupported `pytest-lazy-fixture` python package for tests
+
+  This package is no longer maintained and breaks for `pytest` versions 8+. We do not need it for our tests so
+  it was dropped. In the future if we need to support lazy fixtures we should use the `pytest-lazy-fixtures`
+  package instead (which is actively maintained).
 
 [2.16.11](https://github.com/bird-house/birdhouse-deploy/tree/2.16.11) (2025-08-22)
 ------------------------------------------------------------------------------------------------------------------

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,5 +1,4 @@
 pytest==8.4.1
-pytest-lazy-fixture==0.6.3
 python-dotenv==1.1.1
 jsonschema==4.25.1
 requests==2.32.5

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -134,12 +134,6 @@ pygments==2.19.2 \
 pytest==8.4.1 \
     --hash=sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7 \
     --hash=sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c
-    # via
-    #   -r requirements.in
-    #   pytest-lazy-fixture
-pytest-lazy-fixture==0.6.3 \
-    --hash=sha256:0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac \
-    --hash=sha256:e0b379f38299ff27a653f03eaa69b08a6fd4484e46fd1c9907d984b9f9daeda6
     # via -r requirements.in
 python-dotenv==1.1.1 \
     --hash=sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc \
@@ -348,9 +342,9 @@ tomli==2.2.1 \
     --hash=sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a \
     --hash=sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7
     # via pytest
-typing-extensions==4.14.1 \
-    --hash=sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36 \
-    --hash=sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76
+typing-extensions==4.15.0 \
+    --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
+    --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
     # via
     #   exceptiongroup
     #   referencing

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -45,15 +45,14 @@ def template_substitutions(component_paths):
     return templates
 
 
-@pytest.fixture(scope="module", params=[pytest.lazy_fixture("component_service_configs")])
-def resolved_services_config_schema(request):
+@pytest.fixture(scope="module")
+def resolved_services_config_schema(component_service_configs):
     """
     For each of the services provided by ``component_paths`` fixture, obtain the referenced ``$schema``.
 
     If variable ``DACCS_NODE_REGISTRY_BRANCH`` is defined, the referenced ``$schema`` is ignored in favor of it.
     """
-    service_config_paths = request.param
-    assert service_config_paths, "Invalid service configuration. No service config found."
+    assert component_service_configs, "Invalid service configuration. No service config found."
 
     # test override
     branch = os.environ.get("DACCS_NODE_REGISTRY_BRANCH", None)
@@ -62,11 +61,11 @@ def resolved_services_config_schema(request):
         f"/{branch or 'main'}/node_registry.schema.json#service"
     }
     if branch:
-        return [(default_schema, path) for path in service_config_paths]
+        return [(default_schema, path) for path in component_service_configs]
 
     else:
         service_config_schemas = []
-        for config_path in service_config_paths:
+        for config_path in component_service_configs:
             with open(config_path, mode="r", encoding="utf-8") as config_file:
                 config_data = json.load(config_file)
             if isinstance(config_data, dict):


### PR DESCRIPTION
## Overview

This package is no longer maintained and breaks for `pytest` versions 8+. We do not need it for our tests so it was dropped. In the future if we need to support lazy fixtures we should use the `pytest-lazy-fixtures` package instead (which is actively maintained).

## Changes

**Non-breaking changes**
- minor test changes

**Breaking changes**
- None

## Related Issue / Discussion

- Fixes issue of failed tests in #578 

## Additional Information

@fmigneault I believe you added the lazy-fixture to that specific test. I've removed it as I don't see why this had to be made a lazy fixture. If there is a good reason why it should not be removed please let me know.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
