### PR TITLE
fix weaver landing page media-type links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,9 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Weaver: Fix invalid JSON/HTML media-types for reported `/services` links without explicit format indicator.
 
 [2.17.0](https://github.com/bird-house/birdhouse-deploy/tree/2.17.0) (2025-09-02)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/weaver/service-config.json.template
+++ b/birdhouse/components/weaver/service-config.json.template
@@ -14,8 +14,8 @@
     "links": [
       {
         "rel": "service",
-        "type": "application/json",
-        "href": "${BIRDHOUSE_PROXY_SCHEME}://${BIRDHOUSE_FQDN_PUBLIC}/${WEAVER_MANAGER_NAME}/"
+        "type": "text/html",
+        "href": "${BIRDHOUSE_PROXY_SCHEME}://${BIRDHOUSE_FQDN_PUBLIC}/${WEAVER_MANAGER_NAME}/?f=html"
       },
       {
         "rel": "service-doc",
@@ -25,7 +25,7 @@
       {
         "rel": "service-desc",
         "type": "application/json",
-        "href": "${BIRDHOUSE_PROXY_SCHEME}://${BIRDHOUSE_FQDN_PUBLIC}/${WEAVER_MANAGER_NAME}/"
+        "href": "${BIRDHOUSE_PROXY_SCHEME}://${BIRDHOUSE_FQDN_PUBLIC}/${WEAVER_MANAGER_NAME}/?f=json"
       },
       {
         "rel": "conformance",


### PR DESCRIPTION
## Overview

Fix weaver landing page media-type links reported in `/services`.

Weaver only had JSON responses before (<5.7), but it offers an HTML interface since.
Because browsers push HTML Accept header by default, the assumed links/media-types were not adequate anymore. 

## Changes

**Non-breaking changes**
- Apply the format specifiers to return the corresponding media-types.

**Breaking changes**
- n/a


birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
