### PR TITLE
fix http->https redirects on other methods then GET

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,9 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Proxy: Fix lost HTTP method on redirect to HTTPS.
 
 [2.17.2](https://github.com/bird-house/birdhouse-deploy/tree/2.17.2) (2025-09-12)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/proxy/conf.d/redirect-to-https.include
+++ b/birdhouse/components/proxy/conf.d/redirect-to-https.include
@@ -1,3 +1,3 @@
     location / {
-        return 302 https://$host$request_uri;
+        return 308 https://$host$request_uri;
     }


### PR DESCRIPTION
## Overview

When doing any other request then `GET` using `http://`, the proxy was returning a `302`, leading to lost of the HTTP method. Returning `308` ensures that the HTTP method is preserved during the redirection.

Below is shown the before/after where `302` caused `HTTP POST` to become `HTTPS GET` leading to unexpected response in the context of the original request.

The fixed variant with `308` correctly leads to the `HTTPS POST` (and then the expected unauthorized response in this case).

<img width="600" alt="{5A6B23CC-F275-4138-91CC-B91411EDB69B}" src="https://github.com/user-attachments/assets/a3095adb-69a5-482a-beec-47cfb218b6e0" />


## Changes

**Non-breaking changes**
- Fix the `HTTP->HTTPS` redirection when the method is not `GET`

**Breaking changes**
- If any script was looking explicitly at 302, it won't work anymore, though it shouldn't be doing so in the first place to be resilient to specific 3xx code changes.


## CI Operations


birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
