### PR TITLE
Document development conventions for config vars

### DIFF
--- a/birdhouse/README.rst
+++ b/birdhouse/README.rst
@@ -407,6 +407,13 @@ In order to set up the development environment, run the following commands:
 Development Conventions
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+The aim should be to **avoid** backward **incompatible** changes to decrease manual effort between each
+update. When the effort is low, users will be more likey to stay up to date and not "fear" updates.
+
+We should also aim to be **user-friendly** by being consistent with the way we grow the platform and by
+requiring as little setup/steps (sensible default values) as possible when spin up a fresh new stack
+for onboarding new users.
+
 Adding a new config var to ``env.local``
 ========================================
 * **Default value** should be in a corresponding ``default.env`` so it is easy for the user to find them.


### PR DESCRIPTION
## Overview

Added development conventions for config variables in `env.local`, focusing on minimizing update friction and enhancing user experience.

## Related Issue / Discussion

- https://github.com/bird-house/birdhouse-deploy/pull/616#discussion_r2631306096

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
