### PR TITLE
add bumpversion `[skip ci]` message on commit

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,6 +1,7 @@
 [tool.bumpversion]
 current_version = "2.21.1"
 commit = true
+message = "Bump version: {current_version} → {new_version} [skip ci]"
 tag = false
 tag_name = "{new_version}"
 allow_dirty = true


### PR DESCRIPTION
## Overview

By default, our release procedure makes us create a new commit just to bump the version on each PR, which then creates another commit and a tag once merged. Each of those effectively create duplicate CI runs unnecessarily with the entire (and slow) service instance creation.

To help the CI being more responsive and work on "actual changes", auto-apply `[skip ci]` to the commit to ignore the bumped-version change.

>[!NOTE]
> Would merge this PR as is without again another version bump 😅 

>[!NOTE]
> I will also apply an heuristic ignore of "`Merge branch 'master' into <current-branch>`" on our end of the CI because each time branches are bulk-synched with master, it chokes our CI with unnecessary runs (since other updates typically follow them). If you want to actually run it without further commits after an master-sync, use the `run test` comment approach on the PR.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: true
