### PR TITLE
better bind mount management

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,35 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Changes
+
+- Better management of `service-config.json` files
+
+  Previously the `service-config.json` files were mounted to the `/static/services/` directory on the `proxy` docker 
+  container.
+
+  This mostly worked except that the `/static` directory was itself mounted from a directory on the host machine.
+  This meant that the files mounted to `/static/services` were also visible from the host machine and would remain
+  on the host filesystem after the stack was brought down or updated. To fix this the old files were removed
+  in `proxy/pre-docker-compose-up` but occasionally these files could be owned by the root user which meant that
+  they could not be properly removed. This happens when the docker daemon restarts.
+
+  In order to prevent this, this change instead mounts these files to a different directory (`/static-services`) on
+  the `proxy` docker container that is not within a directory also mounted from the host. This means that there is
+  no additional cleanup required to manage these files.
+
+- Better management of the S3 data files
+
+  Previously the `data/` and `meta/` subdirectories of the files specified by the `S3_DATA_STORE` variable were
+  created in a `pre-docker-compose-up` file that ran on the host machine.
+
+  This works only if these directories can be created as the user executing `pre-docker-compose-up` which is not
+  the case if the parent folder is root owned. If this is the case, then an error is raised when the stack is 
+  brought up and the S3 service is not started.
+
+  In order to prevent this, these subdirectories are now mounted directly as bind mounts to the S3 container which
+  guarantees that they can be created since the user running docker will have permission to create these as bind
+  mounts. 
 
 [2.25.0](https://github.com/bird-house/birdhouse-deploy/tree/2.25.0) (2026-03-17)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/canarie-api/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/canarie-api/config/proxy/docker-compose-extra.yml
@@ -2,6 +2,6 @@ services:
   proxy:
     volumes:
       # note: purposely map to an additional '/canarie' location to match the proxy service location for convenience
-      - ./components/canarie-api/service-config.json:/static/services/canarie.json:ro
-      - ./components/canarie-api/service-config.json:/static/services/canarie-api.json:ro
+      - ./components/canarie-api/service-config.json:/static-services/canarie.json:ro
+      - ./components/canarie-api/service-config.json:/static-services/canarie-api.json:ro
       - ./components/canarie-api/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/canarie-api:ro

--- a/birdhouse/components/cowbird/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/cowbird/config/proxy/docker-compose-extra.yml
@@ -2,7 +2,7 @@ services:
   # extend proxy with endpoint and config for Cowbird API access
   proxy:
     volumes:
-      - ./components/cowbird/service-config.json:/static/services/cowbird.json:ro
+      - ./components/cowbird/service-config.json:/static-services/cowbird.json:ro
       - ./components/cowbird/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/cowbird:ro
     links:
       - cowbird

--- a/birdhouse/components/dggs/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/dggs/config/proxy/docker-compose-extra.yml
@@ -1,5 +1,5 @@
 services:
   proxy:
     volumes:
-      - ./components/dggs/service-config.json:/static/services/dggs.json:ro
+      - ./components/dggs/service-config.json:/static-services/dggs.json:ro
       - ./components/dggs/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/dggs:ro

--- a/birdhouse/components/finch/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/finch/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,4 @@
 services:
   proxy:
     volumes:
-      - ./components/finch/service-config.json:/static/services/finch.json:ro
+      - ./components/finch/service-config.json:/static-services/finch.json:ro

--- a/birdhouse/components/geoserver/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/geoserver/config/proxy/docker-compose-extra.yml
@@ -1,5 +1,5 @@
 services:
   proxy:
     volumes:
-      - ./components/geoserver/service-config.json:/static/services/geoserver.json:ro
+      - ./components/geoserver/service-config.json:/static-services/geoserver.json:ro
       - ./components/geoserver/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/geoserver:ro

--- a/birdhouse/components/hummingbird/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/hummingbird/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,4 @@
 services:
   proxy:
     volumes:
-      - ./components/hummingbird/service-config.json:/static/services/hummingbird.json:ro
+      - ./components/hummingbird/service-config.json:/static-services/hummingbird.json:ro

--- a/birdhouse/components/jupyterhub/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/jupyterhub/config/proxy/docker-compose-extra.yml
@@ -1,5 +1,5 @@
 services:
   proxy:
     volumes:
-      - ./components/jupyterhub/service-config.json:/static/services/jupyterhub.json:ro
+      - ./components/jupyterhub/service-config.json:/static-services/jupyterhub.json:ro
       - ./components/jupyterhub/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/jupyterhub:ro

--- a/birdhouse/components/magpie/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/magpie/config/proxy/docker-compose-extra.yml
@@ -1,5 +1,5 @@
 services:
   proxy:
     volumes:
-      - ./components/magpie/service-config.json:/static/services/magpie.json:ro
+      - ./components/magpie/service-config.json:/static-services/magpie.json:ro
       - ./components/magpie/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/magpie:ro

--- a/birdhouse/components/proxy/conf.d/all-services.include.template
+++ b/birdhouse/components/proxy/conf.d/all-services.include.template
@@ -20,8 +20,8 @@
     }
     location ~ ^/services/(.*)$ {
         default_type application/json;
-        root /static;
-        try_files /services/$1.json =404;
+        root /static-services;
+        try_files /$1.json =404;
     }
 
     location /version {

--- a/birdhouse/components/proxy/pre-docker-compose-up
+++ b/birdhouse/components/proxy/pre-docker-compose-up
@@ -7,7 +7,6 @@ THIS_FILE="$(readlink -f "$0" || realpath "$0")"
 THIS_DIR="$(dirname "${THIS_FILE}")"
 
 # Remove old definitions and ensure docker-dompose detects the change
-rm -f "${THIS_DIR}"/static/services/*
 rm -f "${THIS_DIR}/static/version.json"
 rm -f "${THIS_DIR}/static/services.json"
 rm -f "${THIS_DIR}/static/components.json"

--- a/birdhouse/components/raven/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/raven/config/proxy/docker-compose-extra.yml
@@ -1,4 +1,4 @@
 services:
   proxy:
     volumes:
-      - ./components/raven/service-config.json:/static/services/raven.json:ro
+      - ./components/raven/service-config.json:/static-services/raven.json:ro

--- a/birdhouse/components/s3/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/s3/config/proxy/docker-compose-extra.yml
@@ -2,4 +2,4 @@ services:
   proxy:
     volumes:
       - ./components/s3/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/s3:ro
-      - ./components/s3/service-config.json:/static/services/s3.json:ro
+      - ./components/s3/service-config.json:/static-services/s3.json:ro

--- a/birdhouse/components/s3/docker-compose-extra.yml
+++ b/birdhouse/components/s3/docker-compose-extra.yml
@@ -3,7 +3,9 @@ services:
     image: ${S3_IMAGE}
     container_name: s3
     volumes:
-      - ${S3_DATA_STORE}:/data
+      # Both of these directories need to exist before the service starts so this explicitly creates them both as bind-mounts
+      - ${S3_DATA_STORE}/data:/data/data
+      - ${S3_DATA_STORE}/meta:/data/meta
     environment:
       ROOT_ACCESS_KEY: ${S3_ROOT_ACCESS_KEY}
       ROOT_SECRET_KEY: ${S3_ROOT_SECRET_KEY}

--- a/birdhouse/components/s3/pre-docker-compose-up
+++ b/birdhouse/components/s3/pre-docker-compose-up
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-mkdir -p "${S3_DATA_STORE}/meta" "${S3_DATA_STORE}/data" 

--- a/birdhouse/components/stac-browser/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/stac-browser/config/proxy/docker-compose-extra.yml
@@ -1,5 +1,5 @@
 services:
   proxy:
     volumes:
-      - ./components/stac-browser/service-config.json:/static/services/stac-browser.json:ro
+      - ./components/stac-browser/service-config.json:/static-services/stac-browser.json:ro
       - ./components/stac-browser/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/stac-browser:ro

--- a/birdhouse/components/stac/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/stac/config/proxy/docker-compose-extra.yml
@@ -1,6 +1,6 @@
 services:
   proxy:
     volumes:
-      - ./components/stac/service-config.json:/static/services/stac.json:ro
+      - ./components/stac/service-config.json:/static-services/stac.json:ro
       - ./components/stac/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/stac:ro
       - ./components/stac/config/proxy/conf.extra-directives.d:/etc/nginx/conf.extra-directives.d/stac:ro

--- a/birdhouse/components/thredds/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/thredds/config/proxy/docker-compose-extra.yml
@@ -1,7 +1,7 @@
 services:
   proxy:
     volumes:
-      - ./components/thredds/service-config.json:/static/services/thredds.json:ro
+      - ./components/thredds/service-config.json:/static-services/thredds.json:ro
       - ./components/thredds/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/thredds:ro
     links:
       - thredds

--- a/birdhouse/components/twitcher/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/twitcher/config/proxy/docker-compose-extra.yml
@@ -1,5 +1,5 @@
 services:
   proxy:
     volumes:
-      - ./components/twitcher/service-config.json:/static/services/twitcher.json:ro
+      - ./components/twitcher/service-config.json:/static-services/twitcher.json:ro
       - ./components/twitcher/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/twitcher:ro

--- a/birdhouse/components/weaver/config/proxy/docker-compose-extra.yml
+++ b/birdhouse/components/weaver/config/proxy/docker-compose-extra.yml
@@ -2,7 +2,7 @@ services:
   # extend proxy configuration with weaver endpoints
   proxy:
     volumes:
-      - ./components/weaver/service-config.json:/static/services/weaver.json:ro
+      - ./components/weaver/service-config.json:/static-services/weaver.json:ro
       - ./components/weaver/config/proxy/conf.extra-service.d:/etc/nginx/conf.extra-service.d/weaver:ro
       # because of mounting path naming restrictions (see note in 'worker' definition),
       # we must add the custom path on top of named 'wps_outputs' volume of other birds for the proxy to expose results


### PR DESCRIPTION
## Overview

- Better management of `service-config.json` files

  Previously the `service-config.json` files were mounted to the `/static/services/` directory on the `proxy` docker 
  container.

  This mostly worked except that the `/static` directory was itself mounted from a directory on the host machine.
  This meant that the files mounted to `/static/services` were also visible from the host machine and would remain
  on the host filesystem after the stack was brought down or updated. To fix this the old files were removed
  in `proxy/pre-docker-compose-up` but occasionally these files could be owned by the root user which meant that
  they could not be properly removed. This happens when the docker daemon restarts.

  In order to prevent this, this change instead mounts these files to a different directory (`/static-services`) on
  the `proxy` docker container that is not within a directory also mounted from the host. This means that there is
  no additional cleanup required to manage these files.

- Better management of the S3 data files

  Previously the `data/` and `meta/` subdirectories of the files specified by the `S3_DATA_STORE` variable were
  created in a `pre-docker-compose-up` file that ran on the host machine.

  This works only if these directories can be created as the user executing `pre-docker-compose-up` which is not
  the case if the parent folder is root owned. If this is the case, then an error is raised when the stack is 
  brought up and the S3 service is not started.

  In order to prevent this, these subdirectories are now mounted directly as bind mounts to the S3 container which
  guarantees that they can be created since the user running docker will have permission to create these as bind
  mounts. 

## Changes

**Non-breaking changes**
- fix stack file management behind the scenes

**Breaking changes**
- None

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
