### PR TITLE
Don't call read_configs multiple times unnecessarily when setting up Geoserver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,17 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Don't call `read_configs` multiple times unnecessarily when setting up Geoserver
+
+  The `pre-docker-compose-up` script for Geoserver was calling `read_configs` which was re-setting variables that
+  were already set through `birdhouse-compose.sh`. Then it was potentially calling `read_configs` again if it
+  subsequently called `scripts/fix-geoserver-data-dir-perm`. Not only is this unnecessary but it slows down the
+  script and means that duplicate log messages get displayed to the user.
+
+  Since it is not necessary to call this up to 3 times, this change ensures that `read_configs` is only called when
+  necessary.
 
 [2.25.0](https://github.com/bird-house/birdhouse-deploy/tree/2.25.0) (2026-03-17)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/components/geoserver/pre-docker-compose-up
+++ b/birdhouse/components/geoserver/pre-docker-compose-up
@@ -1,17 +1,7 @@
 #!/bin/sh
 
-THIS_FILE="$(readlink -f "$0" || realpath "$0")"
-THIS_DIR="$(dirname "${THIS_FILE}")"
-COMPOSE_DIR="${COMPOSE_DIR:-$(dirname "${THIS_DIR}/..")}"
-
-if [ -f "${COMPOSE_DIR}/read-configs.include.sh" ]; then
-  . "${COMPOSE_DIR}/read-configs.include.sh"
-
-  # resolve GEOSERVER_DATA_DIR
-  read_configs
-fi
-
 if [ ! -f "${GEOSERVER_DATA_DIR}/global.xml" ]; then
+  eval "$(${BIRDHOUSE_EXE} configs --print-log-command)"
   log INFO "fix GeoServer data dir permission on first run only, when data dir do not exist yet."
   FIRST_RUN_ONLY=1 "${COMPOSE_DIR}/deployment/fix-geoserver-data-dir-perm"
 fi

--- a/birdhouse/deployment/fix-geoserver-data-dir-perm
+++ b/birdhouse/deployment/fix-geoserver-data-dir-perm
@@ -11,20 +11,16 @@
 THIS_FILE="$(readlink -f "$0" || realpath "$0")"
 THIS_DIR="$(dirname "${THIS_FILE}")"
 COMPOSE_DIR="${COMPOSE_DIR:-$(dirname "${THIS_DIR}")}"
+BIRDHOUSE_EXE="${COMPOSE_DIR}/../bin/birdhouse"
 
-. "${COMPOSE_DIR}/read-configs.include.sh"
-
-# Get BASH_IMAGE
-# Get GEOSERVER_DATA_DIR
-read_configs
+if [ -z "${1:-"${GEOSERVER_DATA_DIR}"}" ] || [ -z "${BASH_IMAGE}" ]; then
+    eval "$(${BIRDHOUSE_EXE} configs --print-config-command)"
+    read_configs
+fi
 
 set -x
 
-DATA_DIR="${GEOSERVER_DATA_DIR}"
-
-if [ -n "$1" ]; then
-    DATA_DIR="$1"; shift
-fi
+DATA_DIR="${1:-"${GEOSERVER_DATA_DIR}"}"
 
 docker run --rm --name fix-geoserver-data-dir-perm \
     --volume "${DATA_DIR}":/datadir \


### PR DESCRIPTION
## Overview
  
The `pre-docker-compose-up` script for Geoserver was calling `read_configs` which was re-setting variables that were already set through `birdhouse-compose.sh`. Then it was potentially calling `read_configs` again if it subsequently called `scripts/fix-geoserver-data-dir-perm`. Not only is this unnecessary but it slows down the script and means that duplicate log messages get displayed to the user.

Since it is not necessary to call this up to 3 times, this change ensures that `read_configs` is only called when necessary.

## Changes

**Non-breaking changes**
- optimization

**Breaking changes**
- None

## Related Issue / Discussion

## Additional Information

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: branch_name`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
