### PR TITLE
Display warning message for proxy log rotation properly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,14 @@
 [Unreleased](https://github.com/bird-house/birdhouse-deploy/tree/master) (latest)
 ------------------------------------------------------------------------------------------------------------------
 
-[//]: # (list changes here, using '-' for each new entry, remove this when items are added)
+## Fixes
+
+- Display warning message for proxy log rotation properly
+
+  Since the `./optional-components/proxy-log-volume` can be enabled as a component dependency of
+  `./components/canarie-api` we should be checking for it's presence in `ALL_CONF_DIRS`. Previously
+  we were checking for it in `BIRDHOUSE_EXTRA_CONF_DIRS` which is manually set by the user and doesn't
+  include dynamically added components that are dependants of others.
 
 [2.26.1](https://github.com/bird-house/birdhouse-deploy/tree/2.26.1) (2026-04-09)
 ------------------------------------------------------------------------------------------------------------------

--- a/birdhouse/optional-components/proxy-log-volume/pre-docker-compose-up.include
+++ b/birdhouse/optional-components/proxy-log-volume/pre-docker-compose-up.include
@@ -1,3 +1,3 @@
-if ! echo "${BIRDHOUSE_EXTRA_CONF_DIRS}" | grep -q 'scheduler-job-logrotate-nginx[[:space:]]*$'; then
+if ! echo "${ALL_CONF_DIRS}" | grep -q 'scheduler-job-logrotate-nginx[[:space:]]*$'; then
   log WARN 'Access logs for the proxy component are being written to a regular file but no log rotation is enabled. You may want to enable the scheduler and scheduler-job-logrotate-nginx components.'
 fi


### PR DESCRIPTION
## Overview

Since the `./optional-components/proxy-log-volume` can be enabled as a component dependency of `./components/canarie-api` we should be checking for it's presence in `ALL_CONF_DIRS`. Previously we were checking for it in `BIRDHOUSE_EXTRA_CONF_DIRS` which is manually set by the user and doesn't include dynamically added components that are dependants of others.

## Changes

**Non-breaking changes**

**Breaking changes**

## Related Issue / Discussion

- Resolves #675

## Additional Information

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: {branch_name}`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
