### PR TITLE
prometheus-log-parser: try to fix failed to poll target

### DIFF
--- a/birdhouse/optional-components/prometheus-log-parser/config/monitoring/scrape_configs.yml.template
+++ b/birdhouse/optional-components/prometheus-log-parser/config/monitoring/scrape_configs.yml.template
@@ -1,6 +1,11 @@
 scrape_configs:
   - job_name: log_parser
     honor_labels: true
+    # Default scrape_interval 60s in components/monitoring/prometheus.yml.template
+    # Default scrape_timeout 10s in components/monitoring/prometheus.yml.template
+    # Need long scrape_timeout because prometheus-log-parser takes a long time
+    # to respond to GET http://prometheus-log-parser:8000/metrics
+    scrape_timeout: 55s
     static_configs:
       - targets:
         - prometheus-log-parser:${PROMETHEUS_LOG_PARSER_CLIENT_PORT}


### PR DESCRIPTION
## Overview

Try to fix poll error: "context deadline exceeded".

<img width="951" height="805" alt="Screenshot from 2026-04-14 17-47-58" src="https://github.com/user-attachments/assets/e406aa5a-ff1a-4341-a602-e2813b392138" />

When it works fine with increased  `scrape_timeout`:

<img width="954" height="760" alt="Screenshot from 2026-04-14 18-26-33" src="https://github.com/user-attachments/assets/2b88ebbb-8a41-4c22-b826-99c780542ac1" />

But even 55s `scrape_timeout`, sometime, it is not even enough

<img width="954" height="778" alt="Screenshot from 2026-04-14 19-28-05" src="https://github.com/user-attachments/assets/bd29b121-e924-4d19-ae88-c557d878e4a5" />

But can not have `scrape_timeout` higher than `scrape_interval`.

It would be useful to have some mechanism to diagnose why the prometheus-log-parser takes so much time to respond, see https://github.com/DACCS-Climate/log-parser/issues/6

We do have `export PROMETHEUS_LOG_PARSER_LOG_LEVEL=DEBUG` in `env.local` but this is all we see in `docker logs prometheus-log-parser`, basically nothing useful.

```
2026-04-14 21:36:27,775 - log_parser.log_parser - INFO - file '/var/log/proxy/access_file.log' has been replaced. Tracking will resume from the beginning of the file.
2026-04-14 21:40:46,854 - log_parser.log_parser - INFO - file '/var/log/proxy/access_file.log' has been replaced. Tracking will resume from the beginning of the file.
2026-04-14 21:42:03,771 - log_parser.log_parser - INFO - file '/var/log/proxy/access_file.log' has been replaced. Tracking will resume from the beginning of the file.
2026-04-14 21:45:02,613 - log_parser.log_parser - INFO - file '/var/log/proxy/access_file.log' has been replaced. Tracking will resume from the beginning of the file.
2026-04-14 21:46:00,297 - log_parser.log_parser - INFO - file '/var/log/proxy/access_file.log' has been replaced. Tracking will resume from the beginning of the file.
2026-04-14 21:52:01,214 - log_parser.log_parser - INFO - file '/var/log/proxy/access_file.log' has been replaced. Tracking will resume from the beginning of the file.
```


## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: {branch_name}`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
