### PR TITLE
[skip jenkins] Adjust codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,8 @@
 # review when someone opens a pull request.
 *       @tlvu @fmigneault @mishaschwartz
 
-# For automated GitHub Workflow and other CI updates
-/.github/workflows/*.yml    @birdhouse-helper-bot
-/.gihub/requirements_ci.*   @birdhouse-helper-bot
-/tests/requirements.*       @birdhouse-helper-bot
+# Don't automatically assign reviewers on PRs that only modify these files.
+# As they have no owner listed, these files are not owned by anyone.
+/.github/workflows/*.yml
+/.gihub/requirements_ci.*
+/tests/requirements.*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,8 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @tlvu @fmigneault @mishaschwartz
+
+# For automated GitHub Workflow and other CI updates
+/.github/workflows/*.yml    @birdhouse-helper-bot
+/.gihub/requirements_ci.*   @birdhouse-helper-bot
+/tests/requirements.*       @birdhouse-helper-bot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,5 @@
 # Don't automatically assign reviewers on PRs that only modify these files.
 # As they have no owner listed, these files are not owned by anyone.
 /.github/workflows/*.yml
-/.gihub/requirements_ci.*
+/.github/requirements_ci.*
 /tests/requirements.*


### PR DESCRIPTION
## Overview

This makes certain files typically only touched by Dependabot not "owned" in order to make automatic updates easier.

## Changes

The following files no longer demand CODEOWNER review:
- /.github/workflows/*.yml
- /.gihub/requirements_ci.*
- /tests/requirements.*

## Additional Information

Setting exemptions and allowances for CODEOWNERS only for Dependabot via the GitHub rulesets just doesn't seem to work when PRs are coming from Dependabot. This goes against what I've read in the documentation and feels like an oversight on the part of GitHub.

## CI Operations

<!--
  The test suite can be run using a different DACCS config with ``birdhouse_daccs_configs_branch: {branch_name}`` in the PR description.
  To globally skip the test suite regardless of the commit message use ``birdhouse_skip_ci`` set to ``true`` in the PR description.

  Using ``[<cmd>]`` (with the brackets) where ``<cmd> = skip ci`` in the commit message will override ``birdhouse_skip_ci`` from the PR description.
  Such commit command can be used to override the PR description behavior for a specific commit update.
  However, a commit message cannot 'force run' a PR which the description turns off the CI.
  To run the CI, the PR should instead be updated with a ``true`` value, and a running message can be posted in following PR comments to trigger tests once again.
-->

birdhouse_daccs_configs_branch: master
birdhouse_skip_ci: false
